### PR TITLE
[FEAT] 카카오 로그인 구현 #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 
 	// validation
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -42,6 +44,11 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	testImplementation 'org.testcontainers:mysql:1.19.0'
 	testImplementation 'org.testcontainers:junit-jupiter:1.19.0'
+
+	// JJWT Core
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoTokenResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoTokenResponseDTO.java
@@ -1,0 +1,26 @@
+package com.umc.puppymode2.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoTokenResponseDTO {
+    @JsonProperty("token_type")
+    public String tokenType;
+    @JsonProperty("access_token")
+    public String accessToken;
+    @JsonProperty("id_token")
+    public String idToken;
+    @JsonProperty("expires_in")
+    public Integer expiresIn;
+    @JsonProperty("refresh_token")
+    public String refreshToken;
+    @JsonProperty("refresh_token_expires_in")
+    public Integer refreshTokenExpiresIn;
+    @JsonProperty("scope")
+    public String scope;
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoUserInfoResponseDTO.java
@@ -15,165 +15,165 @@ public class KakaoUserInfoResponseDTO {
 
     //회원 번호
     @JsonProperty("id")
-    public Long id;
+    private Long id;
 
     //자동 연결 설정을 비활성화한 경우만 존재.
     //true : 연결 상태, false : 연결 대기 상태
     @JsonProperty("has_signed_up")
-    public Boolean hasSignedUp;
+    private Boolean hasSignedUp;
 
     //서비스에 연결 완료된 시각. UTC
     @JsonProperty("connected_at")
-    public Date connectedAt;
+    private Date connectedAt;
 
     //카카오싱크 간편가입을 통해 로그인한 시각. UTC
     @JsonProperty("synched_at")
-    public Date synchedAt;
+    private Date synchedAt;
 
     //사용자 프로퍼티
     @JsonProperty("properties")
-    public HashMap<String, String> properties;
+    private HashMap<String, String> properties;
 
     //카카오 계정 정보
     @JsonProperty("kakao_account")
-    public KakaoAccount kakaoAccount;
+    private KakaoAccount kakaoAccount;
 
     //uuid 등 추가 정보
     @JsonProperty("for_partner")
-    public Partner partner;
+    private Partner partner;
 
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class KakaoAccount {
+    public static class KakaoAccount {
 
         //프로필 정보 제공 동의 여부
         @JsonProperty("profile_needs_agreement")
-        public Boolean isProfileAgree;
+        private Boolean isProfileAgree;
 
         //닉네임 제공 동의 여부
         @JsonProperty("profile_nickname_needs_agreement")
-        public Boolean isNickNameAgree;
+        private Boolean isNickNameAgree;
 
         //프로필 사진 제공 동의 여부
         @JsonProperty("profile_image_needs_agreement")
-        public Boolean isProfileImageAgree;
+        private Boolean isProfileImageAgree;
 
         //사용자 프로필 정보
         @JsonProperty("profile")
-        public Profile profile;
+        private Profile profile;
 
         //이름 제공 동의 여부
         @JsonProperty("name_needs_agreement")
-        public Boolean isNameAgree;
+        private Boolean isNameAgree;
 
         //카카오계정 이름
         @JsonProperty("name")
-        public String name;
+        private String name;
 
         //이메일 제공 동의 여부
         @JsonProperty("email_needs_agreement")
-        public Boolean isEmailAgree;
+        private Boolean isEmailAgree;
 
         //이메일이 유효 여부
         // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
         @JsonProperty("is_email_valid")
-        public Boolean isEmailValid;
+        private Boolean isEmailValid;
 
         //이메일이 인증 여부
         //true : 인증된 이메일, false : 인증되지 않은 이메일
         @JsonProperty("is_email_verified")
-        public Boolean isEmailVerified;
+        private Boolean isEmailVerified;
 
         //카카오계정 대표 이메일
         @JsonProperty("email")
-        public String email;
+        private String email;
 
         //연령대 제공 동의 여부
         @JsonProperty("age_range_needs_agreement")
-        public Boolean isAgeAgree;
+        private Boolean isAgeAgree;
 
         //연령대
         //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
         @JsonProperty("age_range")
-        public String ageRange;
+        private String ageRange;
 
         //출생 연도 제공 동의 여부
         @JsonProperty("birthyear_needs_agreement")
-        public Boolean isBirthYearAgree;
+        private Boolean isBirthYearAgree;
 
         //출생 연도 (YYYY 형식)
         @JsonProperty("birthyear")
-        public String birthYear;
+        private String birthYear;
 
         //생일 제공 동의 여부
         @JsonProperty("birthday_needs_agreement")
-        public Boolean isBirthDayAgree;
+        private Boolean isBirthDayAgree;
 
         //생일 (MMDD 형식)
         @JsonProperty("birthday")
-        public String birthDay;
+        private String birthDay;
 
         //생일 타입
         // SOLAR(양력) 혹은 LUNAR(음력)
         @JsonProperty("birthday_type")
-        public String birthDayType;
+        private String birthDayType;
 
         //성별 제공 동의 여부
         @JsonProperty("gender_needs_agreement")
-        public Boolean isGenderAgree;
+        private Boolean isGenderAgree;
 
         //성별
         @JsonProperty("gender")
-        public String gender;
+        private String gender;
 
         //전화번호 제공 동의 여부
         @JsonProperty("phone_number_needs_agreement")
-        public Boolean isPhoneNumberAgree;
+        private Boolean isPhoneNumberAgree;
 
         //전화번호
         //국내 번호인 경우 +82 00-0000-0000 형식
         @JsonProperty("phone_number")
-        public String phoneNumber;
+        private String phoneNumber;
 
         //CI 동의 여부
         @JsonProperty("ci_needs_agreement")
-        public Boolean isCIAgree;
+        private Boolean isCIAgree;
 
         //CI, 연계 정보
         @JsonProperty("ci")
-        public String ci;
+        private String ci;
 
         //CI 발급 시각, UTC
         @JsonProperty("ci_authenticated_at")
-        public Date ciCreatedAt;
+        private Date ciCreatedAt;
 
         @Getter
         @NoArgsConstructor
         @JsonIgnoreProperties(ignoreUnknown = true)
-        public class Profile {
+        public static class Profile {
 
             //닉네임
             @JsonProperty("nickname")
-            public String nickName;
+            private String nickName;
 
             //프로필 미리보기 이미지 URL
             @JsonProperty("thumbnail_image_url")
-            public String thumbnailImageUrl;
+            private String thumbnailImageUrl;
 
             //프로필 사진 URL
             @JsonProperty("profile_image_url")
-            public String profileImageUrl;
+            private String profileImageUrl;
 
             //프로필 사진 URL 기본 프로필인지 여부
             //true : 기본 프로필, false : 사용자 등록
             @JsonProperty("is_default_image")
-            public String isDefaultImage;
+            private Boolean isDefaultImage;
 
             //닉네임이 기본 닉네임인지 여부
             //true : 기본 닉네임, false : 사용자 등록
             @JsonProperty("is_default_nickname")
-            public Boolean isDefaultNickName;
+            private Boolean isDefaultNickName;
 
         }
     }
@@ -181,10 +181,9 @@ public class KakaoUserInfoResponseDTO {
     @Getter
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
-    public class Partner {
+    public static class Partner {
         //고유 ID
         @JsonProperty("uuid")
         public String uuid;
     }
-
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoUserInfoResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/dto/KakaoUserInfoResponseDTO.java
@@ -1,0 +1,190 @@
+package com.umc.puppymode2.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Date;
+import java.util.HashMap;
+
+@Getter
+@NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class KakaoUserInfoResponseDTO {
+
+    //회원 번호
+    @JsonProperty("id")
+    public Long id;
+
+    //자동 연결 설정을 비활성화한 경우만 존재.
+    //true : 연결 상태, false : 연결 대기 상태
+    @JsonProperty("has_signed_up")
+    public Boolean hasSignedUp;
+
+    //서비스에 연결 완료된 시각. UTC
+    @JsonProperty("connected_at")
+    public Date connectedAt;
+
+    //카카오싱크 간편가입을 통해 로그인한 시각. UTC
+    @JsonProperty("synched_at")
+    public Date synchedAt;
+
+    //사용자 프로퍼티
+    @JsonProperty("properties")
+    public HashMap<String, String> properties;
+
+    //카카오 계정 정보
+    @JsonProperty("kakao_account")
+    public KakaoAccount kakaoAccount;
+
+    //uuid 등 추가 정보
+    @JsonProperty("for_partner")
+    public Partner partner;
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class KakaoAccount {
+
+        //프로필 정보 제공 동의 여부
+        @JsonProperty("profile_needs_agreement")
+        public Boolean isProfileAgree;
+
+        //닉네임 제공 동의 여부
+        @JsonProperty("profile_nickname_needs_agreement")
+        public Boolean isNickNameAgree;
+
+        //프로필 사진 제공 동의 여부
+        @JsonProperty("profile_image_needs_agreement")
+        public Boolean isProfileImageAgree;
+
+        //사용자 프로필 정보
+        @JsonProperty("profile")
+        public Profile profile;
+
+        //이름 제공 동의 여부
+        @JsonProperty("name_needs_agreement")
+        public Boolean isNameAgree;
+
+        //카카오계정 이름
+        @JsonProperty("name")
+        public String name;
+
+        //이메일 제공 동의 여부
+        @JsonProperty("email_needs_agreement")
+        public Boolean isEmailAgree;
+
+        //이메일이 유효 여부
+        // true : 유효한 이메일, false : 이메일이 다른 카카오 계정에 사용돼 만료
+        @JsonProperty("is_email_valid")
+        public Boolean isEmailValid;
+
+        //이메일이 인증 여부
+        //true : 인증된 이메일, false : 인증되지 않은 이메일
+        @JsonProperty("is_email_verified")
+        public Boolean isEmailVerified;
+
+        //카카오계정 대표 이메일
+        @JsonProperty("email")
+        public String email;
+
+        //연령대 제공 동의 여부
+        @JsonProperty("age_range_needs_agreement")
+        public Boolean isAgeAgree;
+
+        //연령대
+        //참고 https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#req-user-info
+        @JsonProperty("age_range")
+        public String ageRange;
+
+        //출생 연도 제공 동의 여부
+        @JsonProperty("birthyear_needs_agreement")
+        public Boolean isBirthYearAgree;
+
+        //출생 연도 (YYYY 형식)
+        @JsonProperty("birthyear")
+        public String birthYear;
+
+        //생일 제공 동의 여부
+        @JsonProperty("birthday_needs_agreement")
+        public Boolean isBirthDayAgree;
+
+        //생일 (MMDD 형식)
+        @JsonProperty("birthday")
+        public String birthDay;
+
+        //생일 타입
+        // SOLAR(양력) 혹은 LUNAR(음력)
+        @JsonProperty("birthday_type")
+        public String birthDayType;
+
+        //성별 제공 동의 여부
+        @JsonProperty("gender_needs_agreement")
+        public Boolean isGenderAgree;
+
+        //성별
+        @JsonProperty("gender")
+        public String gender;
+
+        //전화번호 제공 동의 여부
+        @JsonProperty("phone_number_needs_agreement")
+        public Boolean isPhoneNumberAgree;
+
+        //전화번호
+        //국내 번호인 경우 +82 00-0000-0000 형식
+        @JsonProperty("phone_number")
+        public String phoneNumber;
+
+        //CI 동의 여부
+        @JsonProperty("ci_needs_agreement")
+        public Boolean isCIAgree;
+
+        //CI, 연계 정보
+        @JsonProperty("ci")
+        public String ci;
+
+        //CI 발급 시각, UTC
+        @JsonProperty("ci_authenticated_at")
+        public Date ciCreatedAt;
+
+        @Getter
+        @NoArgsConstructor
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public class Profile {
+
+            //닉네임
+            @JsonProperty("nickname")
+            public String nickName;
+
+            //프로필 미리보기 이미지 URL
+            @JsonProperty("thumbnail_image_url")
+            public String thumbnailImageUrl;
+
+            //프로필 사진 URL
+            @JsonProperty("profile_image_url")
+            public String profileImageUrl;
+
+            //프로필 사진 URL 기본 프로필인지 여부
+            //true : 기본 프로필, false : 사용자 등록
+            @JsonProperty("is_default_image")
+            public String isDefaultImage;
+
+            //닉네임이 기본 닉네임인지 여부
+            //true : 기본 닉네임, false : 사용자 등록
+            @JsonProperty("is_default_nickname")
+            public Boolean isDefaultNickName;
+
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public class Partner {
+        //고유 ID
+        @JsonProperty("uuid")
+        public String uuid;
+    }
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/dto/LoginResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/dto/LoginResponseDTO.java
@@ -1,0 +1,29 @@
+package com.umc.puppymode2.domain.user.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class LoginResponseDTO {
+    private String accessToken;
+    private String refreshToken;
+    private LoginUserInfo userInfo;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class LoginUserInfo {
+        @JsonIgnore
+        private Long userId;
+
+        private String username;
+        private Boolean isNewUser;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
@@ -11,7 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
-import jakarta.persistence.Lob;
+import jakarta.persistence.Column;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,18 +29,19 @@ public class SocialAuth extends BaseEntity {
     private Long socialAuthId;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private Provider provider;
 
     private String providerId;
 
-    @Lob
+    @Column(length = 2048)
     private String accessToken;
 
-    @Lob
+    @Column(length = 2048)
     private String refreshToken;
 
     private LocalDateTime tokenExpiry;
@@ -58,5 +59,9 @@ public class SocialAuth extends BaseEntity {
 
     public void setRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
@@ -1,0 +1,62 @@
+package com.umc.puppymode2.domain.user.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import jakarta.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SocialAuth extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long socialAuthId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    private String providerId;
+
+    @Lob
+    private String accessToken;
+
+    @Lob
+    private String refreshToken;
+
+    private LocalDateTime tokenExpiry;
+
+    @Builder
+    public SocialAuth(User user, Provider provider, String providerId,
+                      String accessToken, String refreshToken, LocalDateTime tokenExpiry) {
+        this.user = user;
+        this.provider = provider;
+        this.providerId = providerId;
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+        this.tokenExpiry = tokenExpiry;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -1,0 +1,64 @@
+package com.umc.puppymode2.domain.user.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
+import jakarta.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "`user`")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long userId;
+
+    private String username;
+
+    private String email;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    private Boolean receiveNotifications;
+
+    @Enumerated(EnumType.STRING)
+    private UserStatus status;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SocialAuth> socialAuths = new ArrayList<>();
+
+    @Builder
+    public User(String username,
+                String email,
+                Provider provider,
+                Boolean receiveNotifications,
+                UserStatus status) {
+        this.username = username;
+        this.email = email;
+        this.provider = provider;
+        this.receiveNotifications = receiveNotifications;
+        this.status = status;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -45,12 +45,39 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAuth> socialAuths = new ArrayList<>();
 
+    public void addSocialAuth(SocialAuth socialAuth) {
+        socialAuths.add(socialAuth);
+        socialAuth.setUser(this);
+    }
+
+    public void removeSocialAuth(SocialAuth socialAuth) {
+        socialAuths.remove(socialAuth);
+        socialAuth.setUser(null);
+    }
+
     @Builder
     public User(String username,
                 String email,
                 Provider provider,
                 Boolean receiveNotifications,
                 UserStatus status) {
+
+        if (username == null || username.trim().isEmpty()) {
+            throw new IllegalArgumentException("이름은 필수입니다.");
+        }
+        if (email == null || email.trim().isEmpty()) {
+            throw new IllegalArgumentException("이메일은 필수입니다.");
+        }
+        if (provider == null) {
+            throw new IllegalArgumentException("Provider는 필수입니다.");
+        }
+        if (receiveNotifications == null) {
+            throw new IllegalArgumentException("알림 수신 여부는 필수입니다.");
+        }
+        if (status == null) {
+            throw new IllegalArgumentException("상태 값은 필수입니다.");
+        }
+
         this.username = username;
         this.email = email;
         this.provider = provider;

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/enums/UserStatus.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/enums/UserStatus.java
@@ -1,0 +1,7 @@
+package com.umc.puppymode2.domain.user.entity.enums;
+
+public enum UserStatus {
+    NORMAL, // 기본
+    REST, // 휴면
+    STOP // 탈퇴
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
@@ -16,6 +17,7 @@ public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
     @Query("SELECT sa.refreshToken FROM SocialAuth sa WHERE sa.user.userId = :userId")
     Optional<String> findRefreshTokenByUserId(@Param("userId") Long userId);
 
+    @Transactional
     @Modifying
     @Query("UPDATE SocialAuth sa SET sa.refreshToken = :refreshToken WHERE sa.user.userId = :userId")
     void updateRefreshToken(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
@@ -1,0 +1,22 @@
+package com.umc.puppymode2.domain.user.repository;
+
+import com.umc.puppymode2.domain.user.entity.SocialAuth;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.data.jpa.repository.Modifying;
+
+import java.util.Optional;
+
+public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
+
+    Optional<SocialAuth> findByUser_EmailAndProvider(String email, Provider provider);
+
+    @Query("SELECT sa.refreshToken FROM SocialAuth sa WHERE sa.user.userId = :userId")
+    Optional<String> findRefreshTokenByUserId(@Param("userId") Long userId);
+
+    @Modifying
+    @Query("UPDATE SocialAuth sa SET sa.refreshToken = :refreshToken WHERE sa.user.userId = :userId")
+    void updateRefreshToken(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.umc.puppymode2.domain.user.repository;
+
+import com.umc.puppymode2.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
@@ -1,0 +1,162 @@
+package com.umc.puppymode2.domain.user.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.puppymode2.domain.user.dto.KakaoTokenResponseDTO;
+import com.umc.puppymode2.domain.user.dto.KakaoUserInfoResponseDTO;
+import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
+import com.umc.puppymode2.global.auth.dto.UserAuthInfoDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class KakaoAuthService {
+
+    private final SocialAuthRepository socialAuthRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Qualifier("kakaoWebClient")
+    private final WebClient kakaoWebClient;
+
+    @Qualifier("kakaoTokenWebClient")
+    private final WebClient kakaoTokenWebClient;
+
+
+    @Value("${auth.kakao.rest-api-key}")
+    private String kakaoRestApiKey;
+
+    /**
+     * 카카오 회원의 정보를 가져옵니다.
+     *
+     * @param accessToken
+     * @return 회원 정보 전체
+     */
+    public UserAuthInfoDTO getUserInfo(String accessToken) {
+        KakaoUserInfoResponseDTO userInfo = kakaoWebClient.get()
+                .uri("/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class).map(errorBody -> {
+                            log.error("[Kakao Service] API 에러 응답: {}", errorBody);
+                            handleKakaoApiError(errorBody);
+                            return new RuntimeException("카카오 API 실패");
+                        })
+                )
+                .bodyToMono(KakaoUserInfoResponseDTO.class)
+                .block();
+
+        log.debug("[Kakao Service] raw 응답: {}", toJson(userInfo));
+
+        log.debug("[ Kakao Service ] Auth ID —> {} ", userInfo.getId());
+        log.debug("[ Kakao Service ] NickName —> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
+        log.debug("[ Kakao Service ] email —> {} ", userInfo.getKakaoAccount().getEmail());
+
+        validateKakaoUserInfo(userInfo);
+
+        return UserAuthInfoDTO.builder()
+                .providerId(userInfo.getId().toString())
+                .email(userInfo.getKakaoAccount().getEmail())
+                .username(userInfo.getKakaoAccount().getProfile().getNickName())
+                .build();
+    }
+
+    /**
+     * refreshToken을 사용하여 새로운 accessToken을 발급합니다.
+     */
+    public String refreshAccessToken(Long userId) {
+        String refreshToken = socialAuthRepository.findRefreshTokenByUserId(userId)
+                .orElseThrow(() -> new RuntimeException("Refresh token not found"));
+
+        KakaoTokenResponseDTO tokenResponse = kakaoTokenWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "refresh_token")
+                        .queryParam("client_id", kakaoRestApiKey)
+                        .queryParam("refresh_token", refreshToken)
+                        .build())
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response ->
+                        response.bodyToMono(String.class).map(errorBody -> {
+                            log.error("[Kakao Service] API 에러 응답: {}", errorBody);
+                            handleKakaoApiError(errorBody);
+                            return new RuntimeException("카카오 API 실패");
+                        })
+                )
+                .bodyToMono(KakaoTokenResponseDTO.class)
+                .block();
+        log.debug("[Kakao Service] raw 응답: {}", toJson(tokenResponse));
+
+        if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+            throw new RuntimeException("Failed to refresh Kakao access token");
+        }
+
+        if (tokenResponse.getRefreshToken() != null) {
+            updateRefreshTokenInDB(userId, tokenResponse.getRefreshToken());
+        }
+
+        return tokenResponse.getAccessToken();
+    }
+
+    /**
+     * user_auth 테이블의 refreshToken을 업데이트합니다.
+     */
+    private void updateRefreshTokenInDB(Long userId, String newRefreshToken) {
+        socialAuthRepository.updateRefreshToken(userId, newRefreshToken);
+        log.debug("[Kakao Service] Refresh token updated");
+    }
+
+    /**
+     * 카카오 사용자 정보가 null 인지 검사합니다.
+     */
+    private void validateKakaoUserInfo(KakaoUserInfoResponseDTO userInfo) {
+        if (userInfo == null || userInfo.getId() == null) {
+            throw new IllegalArgumentException("카카오 계정의 고유 ID(auth_id)가 존재하지 않습니다.");
+        }
+
+        if (userInfo.getKakaoAccount() == null) {
+            throw new IllegalArgumentException("카카오 계정 정보가 존재하지 않습니다.");
+        }
+
+        if (userInfo.getKakaoAccount().getProfile() == null ||
+                userInfo.getKakaoAccount().getProfile().getNickName() == null) {
+            throw new IllegalArgumentException("카카오 닉네임 정보가 존재하지 않습니다.");
+        }
+
+        if (userInfo.getKakaoAccount().getEmail() == null) {
+            throw new IllegalArgumentException("카카오 이메일 정보가 존재하지 않습니다.");
+        }
+    }
+
+    /**
+     * 예외 처리
+     */
+    private void handleKakaoApiError(String errorResponse) {
+        if (errorResponse.contains("\"code\": -401")) {
+            throw new IllegalArgumentException("잘못된 Access Token입니다. 재로그인이 필요합니다.");
+        }
+        if (errorResponse.contains("\"code\": -402")) {
+            throw new IllegalStateException("카카오 API 사용량 초과. 잠시 후 다시 시도하세요.");
+        }
+        if (errorResponse.contains("\"code\": -500")) {
+            throw new RuntimeException("카카오 서버 내부 오류 발생. 나중에 다시 시도해주세요.");
+        }
+        throw new RuntimeException("카카오 API 요청 실패: " + errorResponse);
+    }
+
+    private String toJson(Object obj) {
+        try {
+            return objectMapper.writeValueAsString(obj);
+        } catch (JsonProcessingException e) {
+            return "[json 변환 실패]";
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
@@ -21,7 +21,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class KakaoAuthService {
 
     private final SocialAuthRepository socialAuthRepository;
-    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final ObjectMapper objectMapper;
 
     @Qualifier("kakaoWebClient")
     private final WebClient kakaoWebClient;
@@ -54,11 +54,11 @@ public class KakaoAuthService {
                 .bodyToMono(KakaoUserInfoResponseDTO.class)
                 .block();
 
-        log.debug("[Kakao Service] raw 응답: {}", toJson(userInfo));
+//        log.debug("[Kakao Service] raw 응답: {}", toJson(userInfo));
 
-        log.debug("[ Kakao Service ] Auth ID —> {} ", userInfo.getId());
-        log.debug("[ Kakao Service ] NickName —> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
-        log.debug("[ Kakao Service ] email —> {} ", userInfo.getKakaoAccount().getEmail());
+//        log.debug("[ Kakao Service ] Auth ID —> {} ", userInfo.getId());
+//        log.debug("[ Kakao Service ] NickName —> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
+//        log.debug("[ Kakao Service ] email —> {} ", userInfo.getKakaoAccount().getEmail());
 
         validateKakaoUserInfo(userInfo);
 

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Temp 관련 에러
     TEMP_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMP4041", "임시 데이터가 존재하지 않습니다."),
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 에러입니다.");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 에러입니다."),
+
+    // User
+    USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "USER_4001", "이미 탈퇴한 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -14,7 +14,10 @@ public enum SuccessStatus implements BaseCode {
     _OK(HttpStatus.OK, "COMMON200", "성공입니다."),
 
     // Temp 관련 응답
-    TEMP_OK(HttpStatus.OK, "TEMP200", "임시 데이터 조회 성공");
+    TEMP_OK(HttpStatus.OK, "TEMP200", "임시 데이터 조회 성공"),
+
+    // 로그인
+    KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "카카오 로그인 성공");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/puppymode2/global/auth/context/SecurityUserContext.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/context/SecurityUserContext.java
@@ -1,0 +1,46 @@
+package com.umc.puppymode2.global.auth.context;
+
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
+import com.umc.puppymode2.global.security.UserAuthentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SecurityUserContext implements UserContext {
+
+    /**
+     * 현재 인증된 User의 Id를 가져옵니다.
+     */
+    @Override
+    public Long getCurrentUserId() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            log.warn("[SecurityUserContext] 인증 객체가 null입니다.");
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        if (!(authentication instanceof UserAuthentication)) {
+            log.warn("[SecurityUserContext] 인증 객체 타입이 예상과 다릅니다. 현재 타입: {}",
+                    authentication.getClass().getName());
+            log.debug("[SecurityUserContext] authentication 전체 정보: {}", authentication);
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        UserAuthentication userAuthentication = (UserAuthentication) authentication;
+        Long userId = userAuthentication.getUserId();
+
+        if (userId == null) {
+            log.warn("[SecurityUserContext] 인증된 사용자 ID가 null입니다.");
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
+        return userId;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/context/UserContext.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/context/UserContext.java
@@ -1,0 +1,5 @@
+package com.umc.puppymode2.global.auth.context;
+
+public interface UserContext {
+    Long getCurrentUserId();
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/controller/KakaoAuthController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @RestController
@@ -34,6 +35,17 @@ public class KakaoAuthController {
     public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
             @RequestParam("accessToken") String accessToken,
             @RequestParam(value = "refreshToken") String refreshToken) {
+
+        if (!StringUtils.hasText(accessToken)) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.onFailure("VALIDATION_ERROR", "accessToken은 필수입니다.", null));
+        }
+
+        if (!StringUtils.hasText(refreshToken)) {
+            return ResponseEntity.badRequest()
+                    .body(ApiResponse.onFailure("VALIDATION_ERROR", "refreshToken은 필수입니다.", null));
+        }
+
         try {
             UserAuthInfoDTO userInfo = kakaoAuthService.getUserInfo(accessToken);
             LoginResponseDTO loginResponse = userAuthService.createOrUpdateUser(userInfo, Provider.KAKAO, refreshToken);

--- a/src/main/java/com/umc/puppymode2/global/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/controller/KakaoAuthController.java
@@ -1,0 +1,52 @@
+package com.umc.puppymode2.global.auth.controller;
+
+import com.umc.puppymode2.domain.user.dto.LoginResponseDTO;
+import com.umc.puppymode2.domain.user.service.KakaoAuthService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+import com.umc.puppymode2.global.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import com.umc.puppymode2.global.auth.service.UserAuthService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/kakao")
+public class KakaoAuthController {
+
+    private final KakaoAuthService kakaoAuthService;
+    private final UserAuthService userAuthService;
+
+    @GetMapping("/login")
+    @Operation(summary = "카카오 로그인 API",
+            description = "카카오 서버로부터 발급받은 `Access Token`과 `Refresh Token`을 사용하여,  \n" +
+                    "서버에서 JWT를 발급받는 API입니다.  \n" +
+                    "로그인 및 회원가입 처리를 포함합니다.")
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
+            @RequestParam("accessToken") String accessToken,
+            @RequestParam(value = "refreshToken") String refreshToken) {
+        try {
+            UserAuthInfoDTO userInfo = kakaoAuthService.getUserInfo(accessToken);
+            LoginResponseDTO loginResponse = userAuthService.createOrUpdateUser(userInfo, Provider.KAKAO, refreshToken);
+
+            return ResponseEntity.ok(ApiResponse.of(SuccessStatus.KAKAO_LOGIN_SUCCESS, loginResponse));
+        } catch (IllegalArgumentException e) {
+            log.error("카카오 로그인 유효성 오류: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                    .body(ApiResponse.onFailure("VALIDATION_ERROR", e.getMessage(), null));
+        } catch (Exception e) {
+            log.error("카카오 로그인 오류 발생: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.onFailure("AUTH_ERROR", "카카오 로그인 오류가 발생했습니다.", null));
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/dto/UserAuthInfoDTO.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/dto/UserAuthInfoDTO.java
@@ -1,0 +1,20 @@
+package com.umc.puppymode2.global.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserAuthInfoDTO {
+    private String providerId;       // OAuth 제공자의 고유 ID
+    private Long userId;
+    private String email;
+    private String username;
+    private LocalDateTime tokenExpiry; // social access token 의 만료일
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/enums/Provider.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/enums/Provider.java
@@ -1,0 +1,5 @@
+package com.umc.puppymode2.global.auth.enums;
+
+public enum Provider {
+    KAKAO
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthService.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthService.java
@@ -1,0 +1,13 @@
+package com.umc.puppymode2.global.auth.service;
+
+
+import com.umc.puppymode2.domain.user.dto.LoginResponseDTO;
+import com.umc.puppymode2.global.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.global.auth.enums.Provider;
+
+
+public interface UserAuthService {
+
+    // 새로운 회윈 생성 또는 갱신
+    LoginResponseDTO createOrUpdateUser(UserAuthInfoDTO userInfo, Provider authProvider, String refreshToken);
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthServiceImpl.java
@@ -41,7 +41,7 @@ public class UserAuthServiceImpl implements UserAuthService {
         String email = userInfo.getEmail();
         String newUsername = userInfo.getUsername();
 
-        // Todo: providerId로 조회하여 중복 가입 방지 로직 추가 findByProviderIdAndProvider
+        // TODO: providerId로 조회하여 중복 가입 방지 로직 추가 findByProviderIdAndProvider
         Optional<SocialAuth> optionalUserAuth = socialAuthRepository.findByUser_EmailAndProvider(email, provider);
 
         SocialAuth socialAuth;
@@ -119,7 +119,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         return LoginResponseDTO.builder()
                 .accessToken(token)
-                .refreshToken(null) //TODO: refresh 구현
+                .refreshToken(null) // TODO: refresh 구현
                 .userInfo(loginUserInfo)
                 .build();
     }

--- a/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/service/UserAuthServiceImpl.java
@@ -1,0 +1,126 @@
+package com.umc.puppymode2.global.auth.service;
+
+import com.umc.puppymode2.domain.user.dto.LoginResponseDTO;
+import com.umc.puppymode2.domain.user.entity.SocialAuth;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
+import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
+import com.umc.puppymode2.global.exception.GeneralException;
+import com.umc.puppymode2.global.security.UserAuthentication;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class UserAuthServiceImpl implements UserAuthService {
+
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final SocialAuthRepository socialAuthRepository;
+
+    @Transactional
+    @Override
+    public LoginResponseDTO createOrUpdateUser(UserAuthInfoDTO userInfo, Provider provider, String refreshToken) {
+        AtomicBoolean isNewUser = new AtomicBoolean(false);
+
+        String providerId = userInfo.getProviderId();
+        String email = userInfo.getEmail();
+        String newUsername = userInfo.getUsername();
+
+        // Todo: providerId로 조회하여 중복 가입 방지 로직 추가 findByProviderIdAndProvider
+        Optional<SocialAuth> optionalUserAuth = socialAuthRepository.findByUser_EmailAndProvider(email, provider);
+
+        SocialAuth socialAuth;
+        User user;
+
+        // 기존 회원일 경우
+        if (optionalUserAuth.isPresent()) {
+            socialAuth = optionalUserAuth.get();
+            user = socialAuth.getUser();
+
+            if (refreshToken != null && (socialAuth.getRefreshToken() == null || !refreshToken.equals(socialAuth.getRefreshToken()))) {
+                log.debug("Auth Refresh Token 갱신됨.");
+                socialAuth.setRefreshToken(refreshToken);
+                socialAuthRepository.save(socialAuth);
+            }
+
+            if (newUsername != null && !newUsername.equals(user.getUsername())) {
+                log.debug("username 변경됨.");
+                user.setUsername(newUsername);
+                userRepository.save(user);
+            }
+
+            return generateLoginResponse(user, false);
+        }
+
+        // 신규 회원일 경우
+        Optional<User> optionalUser = userRepository.findByEmail(email);
+
+        user = optionalUser.map(existingUser -> {
+            // 탈퇴한 회원인 경우
+            if (existingUser.getStatus() == UserStatus.STOP) {
+                throw new GeneralException(ErrorStatus.USER_ALREADY_WITHDRAWN);
+            }
+            return existingUser;
+        }).orElseGet(() -> {
+            // 새 사용자 생성
+            isNewUser.set(true);
+            User newUser = User.builder()
+                    .username(userInfo.getUsername())
+                    .email(email)
+                    .provider(provider)
+                    .receiveNotifications(false)
+                    .status(UserStatus.NORMAL)
+                    .build();
+            return userRepository.save(newUser);
+        });
+
+        LocalDateTime tokenExpiry = LocalDateTime.now().plusDays(60);
+
+        socialAuth = SocialAuth.builder()
+                .user(user)
+                .provider(provider)
+                .providerId(providerId)
+                .refreshToken(refreshToken)
+                .tokenExpiry(tokenExpiry)
+                .build();
+        socialAuthRepository.save(socialAuth);
+
+        return generateLoginResponse(user, isNewUser.get());
+    }
+
+    /**
+     * JWT 발급 및 응답 생성
+     */
+    private LoginResponseDTO generateLoginResponse(User user, boolean isNewUser) {
+        // 인증 객체 생성
+        Authentication authentication = new UserAuthentication(user.getUserId(), null, null);
+        String token = jwtTokenProvider.generateToken(authentication);
+
+        LoginResponseDTO.LoginUserInfo loginUserInfo = LoginResponseDTO.LoginUserInfo.builder()
+                .userId(user.getUserId())
+                .username(user.getUsername())
+                .isNewUser(isNewUser)
+                .build();
+
+        return LoginResponseDTO.builder()
+                .accessToken(token)
+                .refreshToken(null) //TODO: refresh 구현
+                .userInfo(loginUserInfo)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenProvider.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenProvider.java
@@ -1,0 +1,102 @@
+package com.umc.puppymode2.global.auth.token;
+
+import com.umc.puppymode2.global.security.JwtValidationType;
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Date;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtTokenProvider {
+
+    private static final String USER_ID = "userId";
+    private static final Long TOKEN_EXPIRATION_TIME = 24 * 60 * 60 * 1000L;
+
+    @Value("${auth.jwt.secret}")
+    private String JWT_SECRET;
+
+    @PostConstruct
+    protected void init() {
+        //base64 라이브러리에서 encodeToString을 이용해서 byte[] 형식을 String 형식으로 변환
+        JWT_SECRET = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes(StandardCharsets.UTF_8));
+    }
+
+    public String generateToken(Authentication authentication) {
+        final Date now = new Date();
+
+        final Claims claims = Jwts.claims()
+                .setIssuedAt(now)
+                .setExpiration(new Date(now.getTime() + TOKEN_EXPIRATION_TIME));  // 만료 시간 설정
+
+        claims.put(USER_ID, authentication.getPrincipal());
+
+//        log.info("Claims before signing: {}", claims); // JWT 생성 전 Claims 확인
+        return Jwts.builder()
+                .setHeaderParam(Header.TYPE, Header.JWT_TYPE) // Header
+                .setClaims(claims) // Claim
+                .signWith(getSigningKey()) // Signature
+                .compact();
+    }
+
+    private SecretKey getSigningKey() {
+        String encodedKey = Base64.getEncoder().encodeToString(JWT_SECRET.getBytes()); //SecretKey 통해 서명 생성
+        return Keys.hmacShaKeyFor(encodedKey.getBytes());
+    }
+
+    public JwtValidationType validateToken(String token) {
+//        log.info("JWT Validation Result: {}", token);
+        try {
+            final Claims claims = getBody(token);
+            return JwtValidationType.VALID_JWT;
+        } catch (MalformedJwtException ex) {
+            return JwtValidationType.INVALID_JWT_TOKEN;
+        } catch (ExpiredJwtException ex) {
+            return JwtValidationType.EXPIRED_JWT_TOKEN;
+        } catch (UnsupportedJwtException ex) {
+            return JwtValidationType.UNSUPPORTED_JWT_TOKEN;
+        } catch (IllegalArgumentException ex) {
+            return JwtValidationType.EMPTY_JWT;
+        }
+    }
+
+    private Claims getBody(final String token) {
+//        log.info("Parsing JWT: {}", token);
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    public Long getUserFromJwt(String token) {
+        if (!StringUtils.hasText(token)) {
+//            log.error("JWT is null or empty");
+            throw new IllegalArgumentException("JWT is null or empty");
+        }
+
+        Claims claims = getBody(token);
+//        log.info("Parsed Claims: {}", claims);
+
+        if (claims.get(USER_ID) == null) {
+//            log.error("JWT does not contain userId");
+            throw new IllegalArgumentException("Invalid JWT: missing userId");
+        }
+
+        return Long.valueOf(claims.get("userId").toString());
+    }
+
+
+}
+

--- a/src/main/java/com/umc/puppymode2/global/config/WebClientConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/WebClientConfig.java
@@ -1,0 +1,27 @@
+package com.umc.puppymode2.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean("kakaoWebClient")
+    public WebClient kakaoWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kapi.kakao.com") // 사용자 정보 조회
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .build();
+    }
+
+    @Bean("kakaoTokenWebClient")
+    public WebClient kakaoTokenWebClient() {
+        return WebClient.builder()
+                .baseUrl("https://kauth.kakao.com") // 토큰 갱신용
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/umc/puppymode2/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.umc.puppymode2.global.security;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/security/CustomJwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/umc/puppymode2/global/security/CustomJwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package com.umc.puppymode2.global.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomJwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+        setResponse(response);
+    }
+
+    private void setResponse(HttpServletResponse response) {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,67 @@
+package com.umc.puppymode2.global.security;
+
+import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+import static com.umc.puppymode2.global.security.JwtValidationType.VALID_JWT;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(@NonNull HttpServletRequest request,
+                                    @NonNull HttpServletResponse response,
+                                    @NonNull FilterChain filterChain) throws ServletException, IOException {
+        try {
+            final String token = getJwtFromRequest(request);
+            log.debug("Extracted JWT: {}", token);
+            if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
+                Long userId = jwtTokenProvider.getUserFromJwt(token);
+                // authentication 객체 생성 -> principal에 유저정보를 담는다.
+                UserAuthentication authentication = new UserAuthentication(userId, null, null);
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception exception) {
+            log.error("JWT processing error: {}", exception.getMessage());
+            try {
+                throw new Exception();
+            } catch (Exception e) {
+                log.warn("[JwtAuthenticationFilter] 토큰 인증 실패: {}", e.getMessage());
+            }
+        }
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        log.debug("Authorization Header: {}", bearerToken);
+
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            String token = bearerToken.substring("Bearer ".length());
+            log.debug("Extracted JWT from request: {}", token);
+            return token;
+        }
+
+        log.warn("Authorization header is missing or invalid");
+        return null;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
@@ -31,7 +31,13 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
         try {
             final String token = getJwtFromRequest(request);
-            log.debug("Extracted JWT: {}", token);
+//            log.debug("Extracted JWT: {}", token);
+
+            if (token == null) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             if (jwtTokenProvider.validateToken(token) == VALID_JWT) {
                 Long userId = jwtTokenProvider.getUserFromJwt(token);
                 // authentication 객체 생성 -> principal에 유저정보를 담는다.
@@ -41,11 +47,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         } catch (Exception exception) {
             log.error("JWT processing error: {}", exception.getMessage());
-            try {
-                throw new Exception();
-            } catch (Exception e) {
-                log.warn("[JwtAuthenticationFilter] 토큰 인증 실패: {}", e.getMessage());
-            }
         }
         // 다음 필터로 요청 전달
         filterChain.doFilter(request, response);
@@ -57,7 +58,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             String token = bearerToken.substring("Bearer ".length());
-            log.debug("Extracted JWT from request: {}", token);
+//            log.debug("Extracted JWT from request: {}", token);
             return token;
         }
 

--- a/src/main/java/com/umc/puppymode2/global/security/JwtValidationType.java
+++ b/src/main/java/com/umc/puppymode2/global/security/JwtValidationType.java
@@ -1,0 +1,10 @@
+package com.umc.puppymode2.global.security;
+
+public enum JwtValidationType {
+    VALID_JWT,              // 유효한 JWT
+    INVALID_JWT_SIGNATURE,      // 유효하지 않은 서명
+    INVALID_JWT_TOKEN,          // 유효하지 않은 토큰
+    EXPIRED_JWT_TOKEN,          // 만료된 토큰
+    UNSUPPORTED_JWT_TOKEN,      // 지원하지 않는 형식의 토큰
+    EMPTY_JWT                   // 빈 JWT
+}

--- a/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
@@ -1,0 +1,50 @@
+package com.umc.puppymode2.global.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableWebSecurity
+public class SecurityConfig {
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomJwtAuthenticationEntryPoint customJwtAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/auth/kakao/login/**"
+    };
+
+    private static final String[] SWAGGER_WHITELIST = {
+            "/swagger-ui/**",
+            "/v3/api-docs/**"
+    };
+
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http.csrf(csrf -> csrf.disable())
+                .formLogin(formLogin -> formLogin.disable())
+                .httpBasic(httpBasic -> httpBasic.disable())
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                )
+                .exceptionHandling(exception -> {
+                    exception.authenticationEntryPoint(customJwtAuthenticationEntryPoint);
+                    exception.accessDeniedHandler(customAccessDeniedHandler);
+                })
+                .authorizeHttpRequests(auth -> {
+                    auth.requestMatchers(AUTH_WHITELIST).permitAll();
+                    auth.requestMatchers(SWAGGER_WHITELIST).permitAll();
+                    auth.anyRequest().authenticated();
+                })
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
@@ -18,7 +18,7 @@ public class SecurityConfig {
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     private static final String[] AUTH_WHITELIST = {
-            "/auth/kakao/login/**"
+            "/auth/kakao/login"
     };
 
     private static final String[] SWAGGER_WHITELIST = {

--- a/src/main/java/com/umc/puppymode2/global/security/UserAuthentication.java
+++ b/src/main/java/com/umc/puppymode2/global/security/UserAuthentication.java
@@ -13,6 +13,10 @@ public class UserAuthentication extends UsernamePasswordAuthenticationToken {
     }
 
     public Long getUserId() {
-        return (Long) getPrincipal();
+        Object principal = getPrincipal();
+        if (principal instanceof Long) {
+            return (Long) principal;
+        }
+        throw new IllegalStateException("Principal is not a valid user ID");
     }
 }

--- a/src/main/java/com/umc/puppymode2/global/security/UserAuthentication.java
+++ b/src/main/java/com/umc/puppymode2/global/security/UserAuthentication.java
@@ -1,0 +1,18 @@
+package com.umc.puppymode2.global.security;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+
+public class UserAuthentication extends UsernamePasswordAuthenticationToken {
+
+    // 사용자 인증 객체 생성
+    public UserAuthentication(Long userId, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(userId, credentials, authorities);
+    }
+
+    public Long getUserId() {
+        return (Long) getPrincipal();
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
카카오 로그인을 구현했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #3

## 🔍 작업 내용  
- db에 password 컬럼이 사용되지 않아서 제거했습니다.
- userId 얻는 방법
  - `private final UserContext userContext;`
`Long userId = userContext.getCurrentUserId();`
- 탈퇴한 회원(상태가 탈퇴)은 로그인이 불가능하도록 구현했습니다.
- redis 추가 예정입니다.
- jwt 내부 로직, 로그인 시 중복 가입 로직을 수정 예정입니다.
- 아직 자체 refresh 토큰은 미구현 상태입니다.

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- application.yml 업데이트
- 카카오 로그인 테스트 방법 노션에 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인 인증 및 회원가입 기능이 도입되었습니다.
  * JWT 기반 인증, 토큰 발급 및 검증 기능이 추가되었습니다.
  * 사용자 및 소셜 인증 정보 관리 기능이 구현되었습니다.
  * 카카오 API 연동을 위한 WebClient 설정이 포함되었습니다.
  * Spring Security를 활용한 인증/인가 및 커스텀 예외 처리 기능이 추가되었습니다.
  * Swagger API 문서 및 인증 엔드포인트에 대한 접근 허용이 구성되었습니다.

* **버그 수정**
  * 해당 릴리즈에는 버그 수정 사항이 포함되어 있지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->