### PR TITLE
[FEAT] 온보딩 검사 결과 조회 API 구현 #6

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
@@ -1,0 +1,28 @@
+package com.umc.puppymode2.domain.onboarding.controller;
+
+import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestReqDTO;
+import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestResDTO;
+import com.umc.puppymode2.domain.onboarding.service.OnboardingTestService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/onboarding")
+public class OnboardingController {
+
+    private final OnboardingTestService onboardingTestService;
+
+    @PostMapping("/dog")
+    @Operation(method = "POST", summary = "사용자 선택지에 따른 강아지 추천 API", description = "사용자의 선택지에 따른 강아지를 추천 및 객체 생성해주는 API입니다.")
+    public ApiResponse<OnboardingTestResDTO> recommendAndCreatePuppy(
+            @RequestBody OnboardingTestReqDTO onboardingTestReqDTO) {
+
+        return ApiResponse.onSuccess(onboardingTestService.recommendAndCreatePuppy(onboardingTestReqDTO));
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestResDTO;
 import com.umc.puppymode2.domain.onboarding.service.OnboardingTestService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,10 +19,10 @@ public class OnboardingController {
 
     private final OnboardingTestService onboardingTestService;
 
-    @PostMapping("/dog")
+    @PostMapping("/test")
     @Operation(method = "POST", summary = "사용자 선택지에 따른 강아지 추천 API", description = "사용자의 선택지에 따른 강아지를 추천 및 객체 생성해주는 API입니다.")
     public ApiResponse<OnboardingTestResDTO> recommendAndCreatePuppy(
-            @RequestBody OnboardingTestReqDTO onboardingTestReqDTO) {
+            @Valid @RequestBody OnboardingTestReqDTO onboardingTestReqDTO) {
 
         return ApiResponse.onSuccess(onboardingTestService.recommendAndCreatePuppy(onboardingTestReqDTO));
     }

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestAnswerDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestAnswerDTO.java
@@ -1,8 +1,16 @@
 package com.umc.puppymode2.domain.onboarding.dto;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
 public record OnboardingTestAnswerDTO(
 
+        @Min(value = 1, message = "질문 번호는 1 이상이어야 합니다.")
+        @Max(value = 6, message = "질문 번호는 6 이하여야 합니다.")
         int questionId, // 질문 번호(순서)
+
+        @Min(value = 1, message = "답변은 1 또는 2만 가능합니다.")
+        @Max(value = 2, message = "답변은 1 또는 2만 가능합니다.")
         int answer // 사용자의 선택지 (1 or 2)
 ) {
 }

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestAnswerDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestAnswerDTO.java
@@ -1,0 +1,8 @@
+package com.umc.puppymode2.domain.onboarding.dto;
+
+public record OnboardingTestAnswerDTO(
+
+        int questionId, // 질문 번호(순서)
+        int answer // 사용자의 선택지 (1 or 2)
+) {
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestReqDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestReqDTO.java
@@ -1,0 +1,9 @@
+package com.umc.puppymode2.domain.onboarding.dto;
+
+import java.util.List;
+
+public record OnboardingTestReqDTO(
+
+        List<OnboardingTestAnswerDTO> answers
+) {
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestReqDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestReqDTO.java
@@ -1,9 +1,16 @@
 package com.umc.puppymode2.domain.onboarding.dto;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+
 import java.util.List;
 
 public record OnboardingTestReqDTO(
 
+        @NotEmpty(message = "답변 리스트는 비어있을 수 없습니다.")
+        @Size(min = 6, max = 6, message = "정확히 6개의 답변이 필요합니다.")
+        @Valid
         List<OnboardingTestAnswerDTO> answers
 ) {
 }

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestResDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestResDTO.java
@@ -1,0 +1,10 @@
+package com.umc.puppymode2.domain.onboarding.dto;
+
+public record OnboardingTestResDTO(
+
+        String type, // 예: "분위기 리더형"
+        String puppyBreed, // 예: "비숑 프리제"
+        String description, // 타입에 대한 설명
+        String imageUrl // 강아지 이미지 url
+) {
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/entity/Puppy.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/entity/Puppy.java
@@ -1,0 +1,35 @@
+package com.umc.puppymode2.domain.onboarding.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+public class Puppy extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+//    @ManyToOne(fetch = FetchType.LAZY)
+//    @JoinColumn(name = "user_id")
+//    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "puppy_level_id")
+    private PuppyLevel puppyLevel;
+
+    @Column(name = "puppy_name", nullable = false)
+    private String puppyName;
+
+    @Column(name = "puppy_exp", nullable = false)
+    private Integer puppyExp;
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyLevel.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyLevel.java
@@ -1,0 +1,28 @@
+package com.umc.puppymode2.domain.onboarding.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+public class PuppyLevel extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "puppy_type", nullable = false)
+    private PuppyType puppyType;
+
+    @Column(name = "puppy_level", nullable = false, updatable = false)
+    private Integer puppyLevel;
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyLevel.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyLevel.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Table(name = "puppy_level", uniqueConstraints = @UniqueConstraint(columnNames = {"puppy_type", "puppy_level"}))
 // 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
 // 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
 public class PuppyLevel extends BaseEntity {

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyType.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/entity/PuppyType.java
@@ -1,0 +1,26 @@
+package com.umc.puppymode2.domain.onboarding.entity;
+
+import lombok.Getter;
+
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+@Getter
+public enum PuppyType {
+
+    BICHON("분위기 리더형", "비숑", "술자리를 이끄는 활발하고 감성적인 리더!", "https://example.image.url.com"),
+    SHIBA("은밀한 취객형", "시바견", "혼술을 사랑하는 섬세한 감성가!", "https://example.image.url.com"),
+    CORGI("컨트롤러형", "웰시코기", "술을 도구처럼 다루는 전략가!", "https://example.image.url.com"),
+    POODLE("관찰자형", "푸들", "술자리에서도 분석과 기록을 놓치지 않는 관찰자!", "https://example.image.url.com");
+
+    private final String type; // 성향 이름
+    private final String breed; // 견종
+    private final String description; // 소개 문구
+    private final String imageUrl; // 강아지 대표 이미지
+
+    PuppyType(String type, String breed, String description, String imageUrl) {
+        this.type = type;
+        this.breed = breed;
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/entity/User.java
@@ -1,0 +1,21 @@
+package com.umc.puppymode2.domain.onboarding.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@Builder
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/repository/PuppyLevelRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/repository/PuppyLevelRepository.java
@@ -1,0 +1,14 @@
+package com.umc.puppymode2.domain.onboarding.repository;
+
+import com.umc.puppymode2.domain.onboarding.entity.PuppyLevel;
+import com.umc.puppymode2.domain.onboarding.entity.PuppyType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+public interface PuppyLevelRepository extends JpaRepository<PuppyLevel, Long> {
+
+    Optional<PuppyLevel> findByPuppyTypeAndPuppyLevel(PuppyType puppyType, int level);
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/repository/PuppyRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/repository/PuppyRepository.java
@@ -1,0 +1,9 @@
+package com.umc.puppymode2.domain.onboarding.repository;
+
+import com.umc.puppymode2.domain.onboarding.entity.Puppy;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
+// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
+public interface PuppyRepository extends JpaRepository<Puppy, Long> {
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -1,0 +1,94 @@
+package com.umc.puppymode2.domain.onboarding.service;
+
+import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestAnswerDTO;
+import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestReqDTO;
+import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestResDTO;
+import com.umc.puppymode2.domain.onboarding.entity.Puppy;
+import com.umc.puppymode2.domain.onboarding.entity.PuppyLevel;
+import com.umc.puppymode2.domain.onboarding.entity.PuppyType;
+import com.umc.puppymode2.domain.onboarding.repository.PuppyLevelRepository;
+import com.umc.puppymode2.domain.onboarding.repository.PuppyRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.handler.TempHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class OnboardingTestService {
+
+    private final PuppyRepository puppyRepository;
+    private final PuppyLevelRepository puppyLevelRepository;
+
+    public OnboardingTestResDTO recommendAndCreatePuppy(OnboardingTestReqDTO onboardingTestReqDTO) {
+
+        int eScore = 0, iScore = 0, fScore = 0, tScore = 0; // 각 유형 점수에 해당하는 변수 초기화
+
+        // 모든 답변을 탐색하며 해당하는 유형의 점수를 업데이트
+        for (OnboardingTestAnswerDTO answer : onboardingTestReqDTO.answers()) {
+
+            int q = answer.questionId();
+            int a = answer.answer();
+
+            switch (q) {
+                case 1, 2 -> { // E or I
+                    if (a == 1) eScore++;
+                    else iScore++;
+                }
+                case 5 -> { // E/F or I/T
+                    if (a == 1) {
+                        eScore++; fScore++;
+                    } else {
+                        iScore++; tScore++;
+                    }
+                }
+                case 3, 4, 6 -> { // F or T
+                    if (a == 1) fScore++;
+                    else tScore++;
+                }
+                default -> throw new TempHandler(ErrorStatus.INVALID_QUESTION_ID);
+            }
+        }
+
+        // 두 유형 중 어느쪽에 해당하는지 판별 후 강아지 종 매칭
+        String eOrI = (eScore >= iScore) ? "E" : "I";
+        String fOrT = (fScore >= tScore) ? "F" : "T";
+        PuppyType type = getDogTypeByTrait(eOrI, fOrT);
+
+        // 해당 강아지 타입의 Level 1 찾기
+        PuppyLevel level1 = puppyLevelRepository.findByPuppyTypeAndPuppyLevel(type, 1)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.PUPPY_LEVEL_NOT_FOUND));
+
+        // Puppy 객체 생성 및 저장
+        Puppy puppy = Puppy.builder()
+//                .user(user)
+                .puppyLevel(level1)
+                .puppyName(level1.getPuppyType().getBreed())
+                .puppyExp(0)
+                .build();
+        puppyRepository.save(puppy);
+
+        // 온보딩 화면에 검사 결과로 표시될 데이터 DTO 생성 및 반환
+        return new OnboardingTestResDTO(
+                type.getType(),
+                type.getBreed(),
+                type.getDescription(),
+                type.getImageUrl()
+        );
+    }
+
+    // 도출된 유형에 매칭되는 강아지 종 반환
+    private PuppyType getDogTypeByTrait(String eOrI, String fOrT) {
+        return switch (eOrI + fOrT) {
+            case "EF" -> PuppyType.BICHON;
+            case "IF" -> PuppyType.SHIBA;
+            case "ET" -> PuppyType.CORGI;
+            case "IT" -> PuppyType.POODLE;
+            default -> throw new TempHandler(ErrorStatus.INVALID_TRAIT_COMBINATION);
+        };
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -15,6 +15,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Slf4j
 @Service
 @Transactional
@@ -26,7 +30,9 @@ public class OnboardingTestService {
 
     public OnboardingTestResDTO recommendAndCreatePuppy(OnboardingTestReqDTO onboardingTestReqDTO) {
 
-        int eScore = 0, iScore = 0, fScore = 0, tScore = 0; // 각 유형 점수에 해당하는 변수 초기화
+        // 올바른 reqDTO 형식인지 검증 후, 각 유형 점수에 해당하는 변수 초기화
+        validOnboardingTestReqDTO(onboardingTestReqDTO);
+        int eScore = 0, iScore = 0, fScore = 0, tScore = 0;
 
         // 모든 답변을 탐색하며 해당하는 유형의 점수를 업데이트
         for (OnboardingTestAnswerDTO answer : onboardingTestReqDTO.answers()) {
@@ -79,6 +85,26 @@ public class OnboardingTestService {
                 type.getDescription(),
                 type.getImageUrl()
         );
+    }
+
+    // 올바른 답변 형식인지 검증
+    private void validOnboardingTestReqDTO(OnboardingTestReqDTO onboardingTestReqDTO) {
+
+        Set<Integer> questionIds = onboardingTestReqDTO.answers().stream()
+                .map(OnboardingTestAnswerDTO::questionId)
+                .collect(Collectors.toSet());
+
+        // 중복 questionId 체크
+        Set<Integer> uniqueIds = new HashSet<>(questionIds);
+        if (questionIds.size() != uniqueIds.size()) {
+            throw new TempHandler(ErrorStatus.DUPLICATE_QUESTION_ID);
+        }
+
+        // 모든 질문 번호(1~6)가 포함되어 있는지 체크
+        Set<Integer> expectedIds = Set.of(1, 2, 3, 4, 5, 6);
+        if (!uniqueIds.containsAll(expectedIds)) {
+            throw new TempHandler(ErrorStatus.MISSING_QUESTION_IDS);
+        }
     }
 
     // 도출된 유형에 매칭되는 강아지 종 반환

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -90,19 +90,17 @@ public class OnboardingTestService {
     // 올바른 답변 형식인지 검증
     private void validOnboardingTestReqDTO(OnboardingTestReqDTO onboardingTestReqDTO) {
 
-        Set<Integer> questionIds = onboardingTestReqDTO.answers().stream()
-                .map(OnboardingTestAnswerDTO::questionId)
-                .collect(Collectors.toSet());
-
-        // 중복 questionId 체크
-        Set<Integer> uniqueIds = new HashSet<>(questionIds);
-        if (questionIds.size() != uniqueIds.size()) {
-            throw new TempHandler(ErrorStatus.DUPLICATE_QUESTION_ID);
+        Set<Integer> questionIds = new HashSet<>();
+        for (OnboardingTestAnswerDTO answer : onboardingTestReqDTO.answers()) {
+            // 중복된 questionId가 있을 경우
+            if (!questionIds.add(answer.questionId())) {
+                throw new TempHandler(ErrorStatus.DUPLICATE_QUESTION_ID);
+            }
         }
 
         // 모든 질문 번호(1~6)가 포함되어 있는지 체크
         Set<Integer> expectedIds = Set.of(1, 2, 3, 4, 5, 6);
-        if (!uniqueIds.containsAll(expectedIds)) {
+        if (!questionIds.equals(expectedIds)) {
             throw new TempHandler(ErrorStatus.MISSING_QUESTION_IDS);
         }
     }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -18,7 +18,16 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Temp 관련 에러
     TEMP_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMP4041", "임시 데이터가 존재하지 않습니다."),
-    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 에러입니다.");
+    TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트 에러입니다."),
+
+    // OnboardingTest 에러
+    INVALID_QUESTION_ID(HttpStatus.BAD_REQUEST, "ONBOARD4001", "유효하지 않은 질문 ID입니다."),
+    INVALID_TRAIT_COMBINATION(HttpStatus.INTERNAL_SERVER_ERROR, "ONBOARD5001", "유효하지 않은 성향 조합입니다."),
+
+    // PuppyLevel 에러
+    PUPPY_LEVEL_NOT_FOUND(HttpStatus.NOT_FOUND, "PUPPY4041", "해당 강아지 레벨 정보가 존재하지 않습니다."),
+
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -22,6 +22,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // OnboardingTest 에러
     INVALID_QUESTION_ID(HttpStatus.BAD_REQUEST, "ONBOARD4001", "유효하지 않은 질문 ID입니다."),
+    DUPLICATE_QUESTION_ID(HttpStatus.BAD_REQUEST, "ONBOARD4002", "질문 번호에 중복이 존재합니다."),
+    MISSING_QUESTION_IDS(HttpStatus.BAD_REQUEST, "ONBOARD4003", "모든 질문(1~6번)에 대한 응답이 필요합니다."),
     INVALID_TRAIT_COMBINATION(HttpStatus.INTERNAL_SERVER_ERROR, "ONBOARD5001", "유효하지 않은 성향 조합입니다."),
 
     // PuppyLevel 에러


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 온보딩 화면의 검사 관련 기능
    - 사용자가 선택한 답변 리스트를 받아서, 적절한 강아지 종을 매칭
    - 매칭된 강아지 객체를 생성한 후 강아지 데이터를 반환

- 유저 관련 구현은, 로그인 기능 머지 이후에 변경하도록 하겠습니다!

❓6가지 질문에 답변 시, T/F가 동점이 나올 가능성이 존재 (T/F 갈리는 선택지가 4개 존재하기 때문)
-> 이럴 경우 어떻게 해야 할까요...!

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #6 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **신규 기능**
  * 온보딩 테스트 API가 추가되어 사용자가 질문에 답변하면 성향에 맞는 강아지 유형, 견종, 설명, 이미지 정보를 추천받을 수 있습니다.
  * 온보딩 테스트 관련 엔티티, DTO, 레포지토리, 서비스가 함께 도입되어 추천 로직과 데이터 저장이 가능해졌습니다.

* **버그 수정**
  * 온보딩 테스트 과정에서 발생할 수 있는 잘못된 질문 ID, 중복 질문, 누락된 질문, 유효하지 않은 성향 조합, 존재하지 않는 강아지 레벨에 대한 오류 메시지가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->