### PR TITLE
[FEAT] 목표 관련 API 구현 #9

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
@@ -29,7 +29,7 @@ public class UserGoalHistoryController {
     // 1. 목표 등록 (신규/유지)
     @PostMapping
     @Operation(summary = "목표 등록 API", description = "목표 등록 API 입니다. 새로운 목표는 true, 기존 목표 유지는 false를 넣어주시면 됩니다.")
-    public ResponseEntity<ApiResponse<GoalPostResponseDTO>>postGoal(
+    public ResponseEntity<ApiResponse<GoalPostResponseDTO>> postGoal(
             @RequestBody @Valid GoalPostRequestDTO requestDto) {
 
         Long userId = getCurrentUserId();

--- a/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
@@ -1,0 +1,63 @@
+package com.umc.puppymode2.domain.goal.controller;
+
+import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
+import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
+import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
+import com.umc.puppymode2.domain.goal.service.UserGoalHistoryCommandService;
+import com.umc.puppymode2.domain.goal.service.UserGoalHistoryQueryService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.auth.context.SecurityUserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/goals")
+@RequiredArgsConstructor
+public class UserGoalHistoryController {
+
+    private final UserGoalHistoryCommandService commandService;
+    private final UserGoalHistoryQueryService queryService;
+    private final SecurityUserContext securityUserContext;
+
+    private Long getCurrentUserId() {
+        return securityUserContext.getCurrentUserId();
+    }
+
+    // 1. 목표 등록 (신규/유지)
+    @PostMapping
+    @Operation(summary = "목표 등록 API", description = "목표 등록 API 입니다. 새로운 목표는 true, 기존 목표 유지는 false를 넣어주시면 됩니다.")
+    public ResponseEntity<ApiResponse<GoalPostResponseDTO>>postGoal(
+            @RequestBody @Valid GoalPostRequestDTO requestDto) {
+
+        Long userId = getCurrentUserId();
+        GoalPostResponseDTO response = commandService.postGoal(userId, requestDto);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response, "GOAL200", "목표 등록 성공")
+        );
+    }
+
+    // 2. 최근 목표 조회
+    @GetMapping
+    @Operation(summary = "최근 목표 조회 API", description = "최근 목표 조회 API 입니다.")
+    public ResponseEntity<ApiResponse<GoalInfoResponseDTO>> getLatestGoal() {
+        Long userId = getCurrentUserId();
+        GoalInfoResponseDTO response = queryService.getLatestGoal(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response, "GOAL200", "최근 목표 조회 성공")
+        );
+    }
+
+    // 3. 목표 설정 후 30일 경과 여부
+    @GetMapping("/check-30days")
+    @Operation(summary = "목표 설정 후 30일 경과 여부 API", description = "목표 설정 후 30일 경과 여부 API 입니다.")
+    public ResponseEntity<ApiResponse<Boolean>> check30Days() {
+        Long userId = getCurrentUserId();
+        boolean isPassed = queryService.isMoreThan30DayPassed(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(isPassed, "GOAL200", "목표 설정 후 30일 경과 여부 조회 성공")
+        );
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
@@ -1,0 +1,39 @@
+package com.umc.puppymode2.domain.goal.converter;
+
+import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
+import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class UserGoalHistoryConverter {
+
+    public UserGoalHistory toEntity(GoalPostRequestDTO dto, Long userId) {
+        // null일 경우 기본값 15
+        //int goal = (dto.getGoal() != null) ? dto.getGoal() : 15;
+
+        return UserGoalHistory.builder()
+                .userId(userId)
+                .monthlyGoalCount(dto.getGoal())         // DTO에서 받은 목표
+                .monthlyActualCount(0)                   // 기본값 0
+                .isGoalExceeded(false)                   // 초기에는 목표 초과 X
+                .goalSetAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
+                .updatedAt(LocalDateTime.now())
+                .build();
+    }
+
+
+    public GoalInfoResponseDTO toDto(UserGoalHistory entity) {
+        return GoalInfoResponseDTO.builder()
+                .monthlyGoalCount(entity.getMonthlyGoalCount())
+                .monthlyActualCount(entity.getMonthlyActualCount())
+                .isGoalExceeded(entity.getIsGoalExceeded())
+                .goalSetAt(entity.getGoalSetAt())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
@@ -13,8 +13,9 @@ import java.time.LocalDateTime;
 public class UserGoalHistoryConverter {
 
     public UserGoalHistory toEntity(GoalPostRequestDTO dto, Long userId) {
-        // null일 경우 기본값 15
-        //int goal = (dto.getGoal() != null) ? dto.getGoal() : 15;
+        if (dto.getGoal() == null) {
+            throw new IllegalArgumentException("목표 값은 null일 수 없습니다.");
+        }
 
         return UserGoalHistory.builder()
                 .userId(userId)
@@ -22,8 +23,6 @@ public class UserGoalHistoryConverter {
                 .monthlyActualCount(0)                   // 기본값 0
                 .isGoalExceeded(false)                   // 초기에는 목표 초과 X
                 .goalSetAt(LocalDateTime.now())
-                .createdAt(LocalDateTime.now())
-                .updatedAt(LocalDateTime.now())
                 .build();
     }
 

--- a/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalInfoResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalInfoResponseDTO.java
@@ -1,0 +1,17 @@
+package com.umc.puppymode2.domain.goal.dto;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GoalInfoResponseDTO {
+    private Integer monthlyGoalCount;
+    private Integer monthlyActualCount;
+    private Boolean isGoalExceeded;
+    private LocalDateTime goalSetAt;
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
@@ -1,0 +1,21 @@
+package com.umc.puppymode2.domain.goal.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoalPostRequestDTO {
+    @NotNull(message = "isNew 값은 필수입니다.")
+    private Boolean isNew; // true: 새로운 목표, false: 기존 목표 유지
+
+    @Min(value = 0, message = "목표는 0 이상이어야 합니다.")
+    @Max(value = 30, message = "목표는 30 이하여야 합니다.")
+    private Integer goal; // 새로운 목표 설정 시만 필요
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
@@ -1,7 +1,5 @@
 package com.umc.puppymode2.domain.goal.dto;
 
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostRequestDTO.java
@@ -14,8 +14,5 @@ import lombok.Setter;
 public class GoalPostRequestDTO {
     @NotNull(message = "isNew 값은 필수입니다.")
     private Boolean isNew; // true: 새로운 목표, false: 기존 목표 유지
-
-    @Min(value = 0, message = "목표는 0 이상이어야 합니다.")
-    @Max(value = 30, message = "목표는 30 이하여야 합니다.")
     private Integer goal; // 새로운 목표 설정 시만 필요
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/dto/GoalPostResponseDTO.java
@@ -1,0 +1,13 @@
+package com.umc.puppymode2.domain.goal.dto;
+
+import lombok.*;
+
+@Getter @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class GoalPostResponseDTO {
+    private boolean isSuccess;
+    private String code;
+    private String message;
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
@@ -1,0 +1,46 @@
+package com.umc.puppymode2.domain.goal.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "user_goal_history")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserGoalHistory {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long goalId;
+
+    private Long userId;
+
+    private Integer monthlyGoalCount;  // 이번 달 목표 음주 횟수
+
+    private Integer monthlyActualCount; // 이번 달 실제 음주 횟수
+
+    private Boolean isGoalExceeded;
+
+    private LocalDateTime goalSetAt;
+
+    private LocalDateTime lastGptCommentSentAt;
+
+    private LocalDateTime createdAt;
+
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    public void prePersist() {
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
+    }
+
+    @PreUpdate
+    public void preUpdate() {
+        updatedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
@@ -2,6 +2,8 @@ package com.umc.puppymode2.domain.goal.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import java.time.LocalDateTime;
 
@@ -29,18 +31,11 @@ public class UserGoalHistory {
 
     private LocalDateTime lastGptCommentSentAt;
 
+    @CreationTimestamp
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
+    @UpdateTimestamp
     private LocalDateTime updatedAt;
 
-    @PrePersist
-    public void prePersist() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
-    }
-
-    @PreUpdate
-    public void preUpdate() {
-        updatedAt = LocalDateTime.now();
-    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -1,0 +1,12 @@
+package com.umc.puppymode2.domain.goal.repository;
+
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory, Long> {
+    Optional<UserGoalHistory> findTopByUserIdOrderByGoalSetAtDesc(Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandService.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandService.java
@@ -1,0 +1,8 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
+import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
+
+public interface UserGoalHistoryCommandService {
+    GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO goalPostRequestDTO);
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -21,6 +21,14 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
     @Override
     public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
         if (Boolean.TRUE.equals(dto.getIsNew())) {
+
+            if (dto.getGoal() == null) {
+                throw new IllegalArgumentException("새로운 목표 설정 시 goal 값은 필수입니다.");
+            }
+            if (dto.getGoal() < 0 || dto.getGoal() > 30) {
+                throw new IllegalArgumentException("목표는 0 이상 30 이하여야 합니다.");
+            }
+
             UserGoalHistory newGoal = converter.toEntity(dto, userId);
             repository.save(newGoal);
 
@@ -32,13 +40,15 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
         } else {
             // 기존 목표 유지
             UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
-                    .orElseThrow(() -> new IllegalStateException("기존 목표가 없습니다."));
+                    .orElseThrow(() -> new IllegalArgumentException("기존 목표가 없습니다."));
             UserGoalHistory copiedGoal = UserGoalHistory.builder()
                     .userId(userId)
                     .monthlyGoalCount(lastGoal.getMonthlyGoalCount())
                     .monthlyActualCount(0)
                     .isGoalExceeded(false)
                     .goalSetAt(LocalDateTime.now())
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
                     .build();
 
             repository.save(copiedGoal);

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -1,0 +1,54 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
+import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
+import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommandService {
+    private final UserGoalHistoryRepository repository;
+    private final UserGoalHistoryConverter converter;
+
+    @Transactional
+    @Override
+    public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
+        if (Boolean.TRUE.equals(dto.getIsNew())) {
+            UserGoalHistory newGoal = converter.toEntity(dto, userId);
+            repository.save(newGoal);
+
+            return GoalPostResponseDTO.builder()
+                    .isSuccess(true)
+                    .code("POST_GOAL_SUCCESS")
+                    .message("목표 설정 성공")
+                    .build();
+        } else {
+            // 기존 목표 유지
+            UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+                    .orElseThrow(() -> new IllegalStateException("기존 목표가 없습니다."));
+            UserGoalHistory copiedGoal = UserGoalHistory.builder()
+                    .userId(userId)
+                    .monthlyGoalCount(lastGoal.getMonthlyGoalCount())
+                    .monthlyActualCount(0)
+                    .isGoalExceeded(false)
+                    .goalSetAt(LocalDateTime.now())
+                    .build();
+
+            repository.save(copiedGoal);
+
+            return GoalPostResponseDTO.builder()
+                    .isSuccess(true)
+                    .code("MAINTAIN_GOAL_SUCCESS")
+                    .message("기존 목표 유지 성공")
+                    .build();
+        }
+    }
+}
+

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryService.java
@@ -1,0 +1,8 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
+
+public interface UserGoalHistoryQueryService {
+    GoalInfoResponseDTO getLatestGoal(Long userId);
+    boolean isMoreThan30DayPassed(Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
+import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
+@Service
+@RequiredArgsConstructor
+public class UserGoalHistoryQueryServiceImpl implements UserGoalHistoryQueryService {
+    private final UserGoalHistoryRepository repository;
+    private final UserGoalHistoryConverter converter;
+
+
+    @Override
+    public GoalInfoResponseDTO getLatestGoal(Long userId) {
+        return repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+                .map(converter::toDto)
+                .orElse(null);
+    }
+
+    @Override
+    public boolean isMoreThan30DayPassed(Long userId) {
+        return repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+                .map(goal -> ChronoUnit.DAYS.between(goal.getGoalSetAt(), LocalDateTime.now()) >= 30)
+                .orElse(true);
+
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
목표 관련 API 구현입니다.

## 🔗 관련 이슈  
Closes #9 

## 🔍 작업 내용  
- 목표 등록 API
- 최근 목표 조회 API
- 목표 설정 후 30일 경과 여부

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
음주 기록과 같은 부분들이 구현 되면, 조금 더 구체적인 방향으로 수정 보완하겠습니다. 일단은 단순 등록 및 조회, 30일 경과 여부만 구현해 두었습니다. jwt도 구현해주셔서 로직 수정했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 월별 목표를 등록, 유지, 조회할 수 있는 목표 관리 기능이 추가되었습니다.
  * 최근 목표 정보 조회 및 목표 설정 후 30일 경과 여부 확인이 가능합니다.
  * 목표 등록 및 조회 결과가 일관된 API 응답 형식으로 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->