### PR TITLE
[FEAT] 카카오 유저 탈퇴 (연결끊기) API 구현 #16

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/controller/UserController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package com.umc.puppymode2.domain.user.controller;
+
+import com.umc.puppymode2.domain.user.service.UserCommandService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserCommandService userCommandService;
+    private final UserContext userContext;
+
+    @Operation(
+            summary = "카카오 소셜 회원 탈퇴",
+            description = "카카오 소셜 로그인을 한 사용자가 자신의 계정을 탈퇴(연결끊기)합니다."
+    )
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "탈퇴하기 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 실패/토큰 만료"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "존재하지 않는 유저"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/withdraw")
+    public ResponseEntity<ApiResponse<Void>> withdraw() {
+        Long userId = userContext.getCurrentUserId();
+        userCommandService.withdrawUser(userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null, "POST_WITHDRAW", "탈퇴하기 성공"));
+    }
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/SocialAuth.java
@@ -64,4 +64,8 @@ public class SocialAuth extends BaseEntity {
     public void setUser(User user) {
         this.user = user;
     }
+
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -12,10 +12,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -23,6 +20,7 @@ import java.util.List;
 @Entity
 @Table(name = "`user`")
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
@@ -21,4 +21,6 @@ public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
     @Modifying
     @Query("UPDATE SocialAuth sa SET sa.refreshToken = :refreshToken WHERE sa.user.userId = :userId")
     void updateRefreshToken(@Param("userId") Long userId, @Param("refreshToken") String refreshToken);
+
+    Optional<SocialAuth> findByUserUserIdAndProvider(Long userId, Provider provider);
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
@@ -159,4 +159,30 @@ public class KakaoAuthService {
             return "[json 변환 실패]";
         }
     }
+
+    /**
+     * 카카오 계정 연결 끊기(회원탈퇴)
+     */
+    public boolean disconnectKakao(String accessToken) {
+        try {
+            kakaoWebClient.post()
+                    .uri("/v1/user/unlink")
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(HttpStatusCode::isError, response ->
+                            response.bodyToMono(String.class).map(errorBody -> {
+                                log.error("[Kakao disconnect] API 에러 응답: {}", errorBody);
+                                throw new RuntimeException("카카오 계정 연결 해제 실패: " + errorBody);
+                            })
+                    )
+                    .bodyToMono(Void.class)
+                    .block();
+
+            log.info("[Kakao disconnect] 카카오 계정 연결 해제 성공");
+            return true;
+        } catch (Exception e) {
+            log.error("[Kakao disconnect] 카카오 계정 연결 해제 중 예외 발생", e);
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandService.java
@@ -1,0 +1,5 @@
+package com.umc.puppymode2.domain.user.service;
+
+public interface UserCommandService {
+    void withdrawUser (Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,48 @@
+package com.umc.puppymode2.domain.user.service;
+
+import com.umc.puppymode2.domain.user.entity.SocialAuth;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
+import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.auth.enums.Provider;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService {
+
+    private final UserRepository userRepository;
+    private final SocialAuthRepository socialAuthRepository;
+    private final KakaoAuthService kakaoAuthService;
+
+    @Override
+    @Transactional
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        if (user.getStatus() == UserStatus.STOP) {
+            throw new IllegalArgumentException("이미 탈퇴한 유저입니다.");
+        }
+        SocialAuth socialAuth = socialAuthRepository.findByUserUserIdAndProvider(userId, Provider.KAKAO)
+                .orElseThrow(() -> new IllegalArgumentException("카카오 연동 정보가 없습니다."));
+        String accessToken = socialAuth.getAccessToken();
+        // 1. access token 없거나 만료 시 refresh로 재발급
+        if (accessToken == null) {
+            accessToken = kakaoAuthService.refreshAccessToken(userId);
+            socialAuth.setAccessToken(accessToken);
+            socialAuthRepository.save(socialAuth);
+        }
+        boolean unlinked = kakaoAuthService.disconnectKakao(accessToken);
+        if (!unlinked) {
+            // 운영 로그, 인시던트, Fallback(AdminKey) 여부 정책 검토 후
+            // 서비스 내 유저는 탈퇴처리(soft delete)
+        }
+        user.setStatus(UserStatus.STOP);
+        user.getSocialAuths().clear();
+        userRepository.save(user);
+    }
+
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
카카오 유저 탈퇴(연결끊기) API 구현

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #16 

## 🔍 작업 내용  
- 탈퇴하기 API 구현
   - 유저 정보 및 소셜 인증 정보(SocialAuth) 조회
   - access token이 없으면 refresh token으로 access token 재발급
   - 카카오 unlink API로 연결끊기 실행
   - 유저 status STOP(탈퇴) 처리
   - SocialAuth 연동 정보 삭제

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
@eldeoddt 
- 현재 로그인 구현에서는 access token을 별도로 저장하고 있지 않아서,
탈퇴(연결끊기) 시점에 DB에 저장된 refresh token을 사용해 새로운 access token을 발급받고, 그 access token으로 카카오 unlink API 요청이 이뤄지는 구조입니다.
- SocialAuth 엔티티에 setAccessToken 메서드를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 카카오 소셜 로그인을 통한 사용자 탈퇴(연결 해제) API가 추가되었습니다. 이제 인증된 사용자는 `/users/withdraw` 엔드포인트를 통해 계정 탈퇴를 요청할 수 있습니다.

* **버그 수정**
  * 없음

* **문서화**
  * Swagger/OpenAPI를 통해 사용자 탈퇴 API에 대한 설명 및 응답 코드가 문서화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->