### PR TITLE
[FEAT] 음주 기록 생성 및 음주 기록 상태 조회 구현 #5

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/controller/DrinkHistoryController.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/controller/DrinkHistoryController.java
@@ -1,0 +1,46 @@
+package com.umc.puppymode2.domain.drinkhistory.controller;
+
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
+import com.umc.puppymode2.domain.drinkhistory.service.DrinkHistoryCommandService;
+import com.umc.puppymode2.domain.drinkhistory.service.DrinkHistoryQueryService;
+import com.umc.puppymode2.domain.temp.converter.TempConverter;
+import com.umc.puppymode2.domain.temp.dto.TempRequestDTO;
+import com.umc.puppymode2.domain.temp.dto.TempResponseDTO;
+import com.umc.puppymode2.domain.temp.service.TempCommandService;
+import com.umc.puppymode2.domain.temp.service.TempQueryService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "drink-history-controller", description = "음주 기록 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/drink-history")
+public class DrinkHistoryController {
+    private final DrinkHistoryCommandService drinkHistoryCommandService;
+    private final DrinkHistoryQueryService drinkHistoryQueryService;
+    @Operation(summary = "음주 기록 생성", description = "새로운 음주 기록을 생성합니다.")
+    @PostMapping
+    public ApiResponse<Long> createDrinkHistory(
+            @RequestBody @Valid DrinkHistoryRequestDTO.CreateDrinkHistory request) {
+        Long userId = 1L;
+        Long drinkHistoryId = drinkHistoryCommandService.recordDrink(userId, request);
+        return ApiResponse.onSuccess(drinkHistoryId);
+    }
+
+    @Operation(summary = "음주 기록 상태 조회", description = "음주 기록 상태를 조회합니다.")
+    @GetMapping("/status")
+    public ApiResponse<DrinkHistoryResponseDTO.DrinkStatus> getRecordStatus() {
+        Long userId = 1L;
+        DrinkHistoryResponseDTO.DrinkStatus drinkStatus = drinkHistoryQueryService.getDrinkRecordStatus(userId);
+        return ApiResponse.onSuccess(drinkStatus);
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/converter/DrinkHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/converter/DrinkHistoryConverter.java
@@ -1,0 +1,22 @@
+package com.umc.puppymode2.domain.drinkhistory.converter;
+
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+
+public class DrinkHistoryConverter {
+    public static DrinkHistoryResponseDTO.DrinkStatus toStatusDTO(boolean yesterday, boolean today) {
+        return DrinkHistoryResponseDTO.DrinkStatus.builder()
+                .yesterdayRecorded(yesterday)
+                .todayRecorded(today)
+                .build();
+    }
+
+    public static DrinkHistory toEntity(Long userId, DrinkHistoryRequestDTO.CreateDrinkHistory dto) {
+        return DrinkHistory.builder()
+                .userId(userId)
+                .isDrink(dto.getIsDrink())
+                .drinkDate(dto.getDrinkDate())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryRequestDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryRequestDTO.java
@@ -1,0 +1,24 @@
+package com.umc.puppymode2.domain.drinkhistory.dto;
+
+import com.umc.puppymode2.domain.temp.entity.enums.TempStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public class DrinkHistoryRequestDTO {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CreateDrinkHistory {
+        private LocalDate drinkDate;
+        private Boolean isDrink;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryResponseDTO.java
@@ -1,0 +1,16 @@
+package com.umc.puppymode2.domain.drinkhistory.dto;
+
+import lombok.*;
+
+public class DrinkHistoryResponseDTO {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DrinkStatus {
+        private boolean yesterdayRecorded;
+        private boolean todayRecorded;
+    }
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/entity/DrinkHistory.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/entity/DrinkHistory.java
@@ -1,0 +1,33 @@
+package com.umc.puppymode2.domain.drinkhistory.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import jakarta.persistence.Entity;
+import lombok.*;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class DrinkHistory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long drinkHistoryId;
+
+//    @ManyToOne
+//    @JoinColumn(name = "user_id")
+//    private User user;
+    private Long userId;
+
+    @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+    private Boolean isDrink = true;
+
+    @Column(nullable = false)
+    private LocalDate drinkDate;
+
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.umc.puppymode2.domain.drinkhistory.repository;
+
+
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+
+@Repository
+public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
+    boolean existsByUserIdAndDrinkDate(Long userId, LocalDate date);
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandService.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandService.java
@@ -1,0 +1,8 @@
+package com.umc.puppymode2.domain.drinkhistory.service;
+
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import jakarta.validation.Valid;
+
+public interface DrinkHistoryCommandService {
+    Long recordDrink(Long userId, DrinkHistoryRequestDTO.CreateDrinkHistory dto);
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -1,0 +1,29 @@
+package com.umc.puppymode2.domain.drinkhistory.service;
+
+import com.umc.puppymode2.domain.drinkhistory.converter.DrinkHistoryConverter;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandService {
+
+    private final DrinkHistoryRepository drinkHistoryRepository;
+
+    @Override
+    public Long recordDrink(Long userId, DrinkHistoryRequestDTO.CreateDrinkHistory dto) {
+        boolean alreadyExists = drinkHistoryRepository.existsByUserIdAndDrinkDate(userId, dto.getDrinkDate());
+        if (alreadyExists) {
+            throw new IllegalStateException("이미 해당 날짜에 음주 기록이 존재합니다.");
+        }
+        DrinkHistory drinkHistory = drinkHistoryRepository.save(DrinkHistoryConverter.toEntity(userId, dto));
+        return drinkHistory.getDrinkHistoryId();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryService.java
@@ -1,0 +1,7 @@
+package com.umc.puppymode2.domain.drinkhistory.service;
+
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
+
+public interface DrinkHistoryQueryService {
+    DrinkHistoryResponseDTO.DrinkStatus getDrinkRecordStatus(Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryServiceImpl.java
@@ -1,0 +1,27 @@
+package com.umc.puppymode2.domain.drinkhistory.service;
+
+import com.umc.puppymode2.domain.drinkhistory.converter.DrinkHistoryConverter;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DrinkHistoryQueryServiceImpl implements DrinkHistoryQueryService {
+    private final DrinkHistoryRepository drinkHistoryRepository;
+    @Override
+    public DrinkHistoryResponseDTO.DrinkStatus getDrinkRecordStatus(Long userId) {
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+
+        boolean hasToday = drinkHistoryRepository.existsByUserIdAndDrinkDate(userId, today);
+        boolean hasYesterday = drinkHistoryRepository.existsByUserIdAndDrinkDate(userId, yesterday);
+
+        return DrinkHistoryConverter.toStatusDTO(hasYesterday, hasToday);
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
음주 기록 생성 및 음주 기록 상태 조회 구현

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #5 

## 🔍 작업 내용  
- 음주 기록 생성
- 음주 기록 상태 조회

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 음수 기록 생성 및 조회를 위한 새로운 API 엔드포인트가 추가되었습니다.
  * 사용자는 음수 기록을 생성하고, 어제와 오늘의 음수 기록 여부를 확인할 수 있습니다.

* **기타**
  * 음수 기록 관련 데이터 전송 객체(DTO), 변환기, 엔티티, 서비스 및 저장소가 새롭게 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->