### PR TITLE
[FEAT] 음주 리포트 API 틀 구현 #20

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
@@ -1,0 +1,31 @@
+package com.umc.puppymode2.domain.report.controller;
+
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import com.umc.puppymode2.domain.report.service.DrinkReportService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.auth.context.SecurityUserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/report")
+@RequiredArgsConstructor
+public class DrinkReportController {
+
+    private final DrinkReportService drinkReportService;
+    private final SecurityUserContext securityUserContext;
+
+    @GetMapping
+    @Operation(summary = "목표 리포트 API", description = "목표 리포트 조회 API 입니다.")
+    public ResponseEntity<ApiResponse<DrinkReportResponseDTO>> getDrinkReport() {
+        Long userId = securityUserContext.getCurrentUserId();
+        DrinkReportResponseDTO response = drinkReportService.drinkReport(userId);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess(response, "REPORT200","음주 리포트 조회 성공" )
+        );
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/report/converter/DrinkReportConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/converter/DrinkReportConverter.java
@@ -1,0 +1,17 @@
+package com.umc.puppymode2.domain.report.converter;
+
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DrinkReportConverter {
+    public DrinkReportResponseDTO toDto(Integer goal, Integer drinkCount, Integer drinkDays, Integer achievementRate, Integer scoldedCount) {
+        return DrinkReportResponseDTO.builder()
+                .goal(goal)
+                .drinkRecordCount(drinkCount)
+                .drinkDays(drinkDays)
+                .achievementRate(achievementRate)
+                .scoldedCount(scoldedCount)
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/report/dto/DrinkReportResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/dto/DrinkReportResponseDTO.java
@@ -1,0 +1,16 @@
+package com.umc.puppymode2.domain.report.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DrinkReportResponseDTO {
+    private Integer goal;
+    private Integer drinkRecordCount;
+    private Integer drinkDays;
+    private Integer achievementRate;
+    private Integer scoldedCount;
+}

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportService.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportService.java
@@ -1,0 +1,7 @@
+package com.umc.puppymode2.domain.report.service;
+
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+
+public interface DrinkReportService {
+    DrinkReportResponseDTO drinkReport(Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -1,0 +1,48 @@
+package com.umc.puppymode2.domain.report.service;
+
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class DrinkReportServiceImpl implements DrinkReportService {
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
+    // private final DrinkHistoryRepository drinkHistoryRepository; 음주 기록이 나오면 추가
+    private final DrinkReportConverter drinkReportConverter;
+
+    @Transactional
+    @Override
+    public DrinkReportResponseDTO drinkReport(Long userId) {
+        LocalDate now = LocalDate.now();
+        LocalDate firstDayOfMonth = now.withDayOfMonth(1);
+        LocalDate lastDayOfMonth = now.withDayOfMonth(now.lengthOfMonth());
+
+        int goal = userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+                .map(UserGoalHistory::getMonthlyGoalCount)
+                .orElse(15); // 기본값 15
+
+        // 임시 값. 음주기록 구현되면 하기.
+        int drinkRecordCount = 0;
+
+        int drinkDays = 0;
+
+        int achievementRate = 0;
+
+        int scoldedCount = 0;
+
+        DrinkReportResponseDTO dto = drinkReportConverter.toDto(goal, drinkRecordCount, drinkDays, achievementRate, scoldedCount);
+
+        return dto;
+    }
+
+    // 리포트 관련 로직 계산 -> 음주 기록 후
+
+
+}


### PR DESCRIPTION
# 🚀 PR 개요  
음주 리포트 조회 API를 구현합니다.
필요한 값들은 기본값으로 일단 두었습니다.

## 🔗 관련 이슈  
Closes #20

## 🔍 작업 내용  
- 음주 리포트 조회 API 틀 구현


## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
음주 기록이 완성되면 세부 계산 로직을 추가할 예정이며, 기본값으로 설정된 부분은 추후 수정예정이며, 주석으로 처리했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 자신의 음수(마시기) 리포트를 조회할 수 있는 새로운 API가 추가되었습니다.
  * 리포트에는 목표, 음수 기록 수, 음수한 일수, 달성률, 꾸중 횟수 등의 정보가 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->