### PR TITLE
[FEAT] 메인 화면 조회 API 구현 #19

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/controller/MainController.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/controller/MainController.java
@@ -1,0 +1,25 @@
+package com.umc.puppymode2.domain.puppy.controller;
+
+import com.umc.puppymode2.domain.puppy.dto.MainResponseDto;
+import com.umc.puppymode2.domain.puppy.service.MainService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/main")
+@RequiredArgsConstructor
+public class MainController {
+
+    private final MainService mainService;
+
+    @GetMapping
+    @Operation(method = "GET", summary = "메인 화면 조회 API", description = "사용자의 메인 화면 정보를 반환하는 API입니다.")
+    public ApiResponse<MainResponseDto> getMain() {
+        MainResponseDto result = mainService.getMainPageInfo();
+        return ApiResponse.onSuccess(result, "GET_MAIN_SUCCESS", "메인 화면 조회 성공");
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
@@ -1,0 +1,26 @@
+package com.umc.puppymode2.domain.puppy.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class MainResponseDto {
+    private int puppyLevel;          // 강아지 레벨
+    private String puppyLevelName;   // 레벨 이름
+    private int puppyLevelPercent;   // 경험치 진행률(%)
+    private String puppyImageUrl;    // 강아지 레벨 이미지 URL
+
+    @JsonProperty("isPuppyName")
+    private boolean puppyName;     // 강아지 이름 지어주기 여부
+
+    @JsonProperty("isMyName")
+    private boolean myName;        // 내 이름 알려주기 여부
+
+    @JsonProperty("isGoal")
+    private boolean goal;          // 이번 달 목표 설정 여부
+
+    private boolean didRecordYesterday; // 어제 기록 완료 여부
+    private boolean didRecordToday;  // 오늘 기록 완료 여부
+}

--- a/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
@@ -32,7 +32,11 @@ public class Puppy extends BaseEntity {
     @Column(name = "puppy_exp", nullable = false)
     private Integer puppyExp;
 
+    @Column(name = "is_custom_name", nullable = false)
+    private boolean isCustomName = false;
+
     public void setPuppyName(String name) {
         this.puppyName = name;
+        this.isCustomName = true;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/entity/PuppyType.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/entity/PuppyType.java
@@ -2,8 +2,6 @@ package com.umc.puppymode2.domain.puppy.entity;
 
 import lombok.Getter;
 
-// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
-// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
 @Getter
 public enum PuppyType {
 

--- a/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyLevelRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyLevelRepository.java
@@ -6,8 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
-// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
 public interface PuppyLevelRepository extends JpaRepository<PuppyLevel, Long> {
 
     Optional<PuppyLevel> findByPuppyTypeAndPuppyLevel(PuppyType puppyType, int level);

--- a/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
@@ -5,8 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-// 관련된 엔티티/enum/repository 가 미리 생성되지 않아 임시로 구현한 파일입니다.
-// 이후 다른 분들 코드도 머지되면, 해당 코드 속 파일로 import 변경하도록 하겠습니다!
 public interface PuppyRepository extends JpaRepository<Puppy, Long> {
     Optional<Puppy> findByUser_UserId(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainService.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainService.java
@@ -1,0 +1,7 @@
+package com.umc.puppymode2.domain.puppy.service;
+
+import com.umc.puppymode2.domain.puppy.dto.MainResponseDto;
+
+public interface MainService {
+    MainResponseDto getMainPageInfo();
+}

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -1,0 +1,83 @@
+package com.umc.puppymode2.domain.puppy.service;
+
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.puppy.dto.MainResponseDto;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.entity.PuppyLevel;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import com.umc.puppymode2.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+public class MainServiceImpl implements MainService {
+
+    private final PuppyRepository puppyRepository;
+    private final UserRepository userRepository;
+    private final DrinkHistoryRepository drinkHistoryRepository;
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
+    private final UserContext userContext;
+
+    @Override
+    public MainResponseDto getMainPageInfo() {
+        Long userId = userContext.getCurrentUserId();
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        Puppy puppy = puppyRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+
+        PuppyLevel level = puppy.getPuppyLevel();
+
+        int percent = calculateExp(puppy, level);
+
+        boolean isPuppyName = puppy.isCustomName();
+        boolean isMyName = user.isCustomName();
+
+        boolean isGoal = userGoalHistoryRepository
+                .findTopByUserIdOrderByGoalSetAtDesc(userId)
+                .filter(h -> h.getGoalSetAt().getYear() == LocalDate.now().getYear()
+                        && h.getGoalSetAt().getMonthValue() == LocalDate.now().getMonthValue())
+                .isPresent();
+
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+        boolean didRecordYesterday = drinkHistoryRepository.existsByUserIdAndDrinkDate(userId, yesterday);
+        boolean didRecordToday = drinkHistoryRepository.existsByUserIdAndDrinkDate(userId, today);
+
+        return MainResponseDto.builder()
+                .puppyLevel(level.getPuppyLevel())
+                .puppyLevelName(level.getLevelName())
+                .puppyLevelPercent(percent)
+                .puppyImageUrl(level.getLevelImageUrl())
+                .puppyName(isPuppyName)
+                .myName(isMyName)
+                .goal(isGoal)
+                .didRecordYesterday(didRecordYesterday)
+                .didRecordToday(didRecordToday)
+                .build();
+    }
+
+    private int calculateExp(Puppy puppy, PuppyLevel level) {
+        long currentExp = puppy.getPuppyExp();
+        long minExp = level.getLevelMinExp();
+        long maxExp = level.getLevelMaxExp();
+
+        double ratio = (double) (currentExp - minExp) / (double) (maxExp - minExp);
+        int percent = (int) Math.round(ratio * 100);
+        if (percent < 0) percent = 0;
+        else if (percent > 100) percent = 100;
+
+        return percent;
+    }
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameService.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameService.java
@@ -1,29 +1,7 @@
 package com.umc.puppymode2.domain.puppy.service;
 
 import com.umc.puppymode2.domain.puppy.dto.PuppyNameRequestDto;
-import com.umc.puppymode2.domain.puppy.entity.Puppy;
-import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.auth.context.UserContext;
-import com.umc.puppymode2.global.exception.GeneralException;
-import jakarta.transaction.Transactional;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
 
-@Service
-@RequiredArgsConstructor
-public class PuppyNameService {
-
-    private final PuppyRepository puppyRepository;
-    private final UserContext userContext;
-
-    @Transactional
-    public void updatePuppyName(PuppyNameRequestDto requestDto) {
-        Long userId = userContext.getCurrentUserId();
-
-        Puppy puppy = puppyRepository.findByUser_UserId(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
-
-        puppy.setPuppyName(requestDto.getPuppyName());
-    }
+public interface PuppyNameService {
+    void updatePuppyName(PuppyNameRequestDto requestDto);
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameServiceImpl.java
@@ -1,0 +1,30 @@
+package com.umc.puppymode2.domain.puppy.service;
+
+import com.umc.puppymode2.domain.puppy.dto.PuppyNameRequestDto;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import com.umc.puppymode2.global.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PuppyNameServiceImpl implements PuppyNameService {
+
+    private final PuppyRepository puppyRepository;
+    private final UserContext userContext;
+
+    @Override
+    @Transactional
+    public void updatePuppyName(PuppyNameRequestDto requestDto) {
+        Long userId = userContext.getCurrentUserId();
+
+        Puppy puppy = puppyRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+
+        puppy.setPuppyName(requestDto.getPuppyName());
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -3,15 +3,7 @@ package com.umc.puppymode2.domain.user.entity;
 import com.umc.puppymode2.domain.common.BaseEntity;
 import com.umc.puppymode2.global.auth.enums.Provider;
 import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
-import jakarta.persistence.Id;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 
 import java.util.ArrayList;
@@ -40,6 +32,9 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private UserStatus status;
 
+    @Column(name = "is_custom_name", nullable = false)
+    private boolean isCustomName = false;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAuth> socialAuths = new ArrayList<>();
 
@@ -58,7 +53,8 @@ public class User extends BaseEntity {
                 String email,
                 Provider provider,
                 Boolean receiveNotifications,
-                UserStatus status) {
+                UserStatus status,
+                boolean isCustomName) {
 
         if (username == null || username.trim().isEmpty()) {
             throw new IllegalArgumentException("이름은 필수입니다.");
@@ -81,9 +77,11 @@ public class User extends BaseEntity {
         this.provider = provider;
         this.receiveNotifications = receiveNotifications;
         this.status = status;
+        this.isCustomName = isCustomName;
     }
 
     public void setUsername(String username) {
         this.username = username;
+        this.isCustomName = true;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserNameService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserNameService.java
@@ -1,28 +1,7 @@
 package com.umc.puppymode2.domain.user.service;
 
 import com.umc.puppymode2.domain.user.dto.UserNameUpdateRequestDto;
-import com.umc.puppymode2.domain.user.entity.User;
-import com.umc.puppymode2.domain.user.repository.UserRepository;
-import com.umc.puppymode2.global.auth.context.UserContext;
-import com.umc.puppymode2.global.exception.GeneralException;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
-@Service
-@RequiredArgsConstructor
-public class UserNameService {
-
-    private final UserRepository userRepository;
-    private final UserContext userContext;
-
-    @Transactional
-    public void updateUsername(UserNameUpdateRequestDto requestDto) {
-        Long userId = userContext.getCurrentUserId();
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        user.setUsername(requestDto.getMyName());
-    }
+public interface UserNameService {
+    void updateUsername(UserNameUpdateRequestDto requestDto);
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserNameServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserNameServiceImpl.java
@@ -1,0 +1,29 @@
+package com.umc.puppymode2.domain.user.service;
+
+import com.umc.puppymode2.domain.user.dto.UserNameUpdateRequestDto;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import com.umc.puppymode2.global.exception.GeneralException;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserNameServiceImpl implements UserNameService {
+
+    private final UserRepository userRepository;
+    private final UserContext userContext;
+
+    @Override
+    @Transactional
+    public void updateUsername(UserNameUpdateRequestDto requestDto) {
+        Long userId = userContext.getCurrentUserId();
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        user.setUsername(requestDto.getMyName());
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
메인 화면 조회 API 구현

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #19 

## 🔍 작업 내용  
- 메인 화면 조회 API 구현
- 이름 관리 API 서비스 인터페이스/구현체 분리

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
## 💬 Remarks  
- 메인 페이지 조회는 여러 도메인의 정보를 포함하므로, 일단 `Main`으로 통일하여 `Puppy` 패키지 내에 구성했습니다. 네이밍 관련 다른 의견이 있다면 말씀 부탁드립니다.
- 또한 메인 페이지 조회 시 이름 설정 여부를 확인하기 위해(기본 이름이 자동으로 부여됩니다) `User`와 `Puppy` 엔티티에 `isCustomName` 필드를 추가했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 메인 화면 정보를 조회하는 새로운 API 엔드포인트가 추가되었습니다.
  * 강아지 및 사용자 이름 커스텀 여부, 목표 설정, 기록 여부 등 메인 화면에 필요한 상태 정보가 제공됩니다.

* **버그 수정**
  * 없음

* **리팩터**
  * 강아지 및 사용자 이름 변경 서비스가 인터페이스와 구현 클래스로 분리되었습니다.
  * 엔티티에 커스텀 이름 여부를 나타내는 필드가 추가되었습니다.

* **스타일/문서**
  * 임시 주석 및 불필요한 설명이 코드에서 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->