### PR TITLE
[FEAT] 캘린더 조회 API 구현 #22

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/calendar/controller/CalendarController.java
+++ b/src/main/java/com/umc/puppymode2/domain/calendar/controller/CalendarController.java
@@ -1,0 +1,36 @@
+package com.umc.puppymode2.domain.calendar.controller;
+
+import com.umc.puppymode2.domain.calendar.dto.CalendarResponseDTO;
+import com.umc.puppymode2.domain.calendar.service.CalendarQueryService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+import com.umc.puppymode2.global.auth.context.SecurityUserContext;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Tag(name = "calendar-controller", description = "캘린더 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/calendar")
+public class CalendarController {
+    private final CalendarQueryService calendarQueryService;
+    private final UserContext userContext;
+
+    @Operation(summary = "캘린더 조회", description = "캘린더를 조회하는 API 입니다.")
+    @GetMapping
+    public ApiResponse<List<CalendarResponseDTO>> getCalendar(@RequestParam int year,
+                                                              @RequestParam int month) {
+        Long userId = userContext.getCurrentUserId();
+        List<CalendarResponseDTO> drinkStatus = calendarQueryService.getCalendar(userId, year, month);
+        return ApiResponse.onSuccess(drinkStatus, SuccessStatus.CALENDAR_GET_SUCCESS.getCode(), SuccessStatus.CALENDAR_GET_SUCCESS.getMessage());
+    }
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/calendar/converter/CalendarConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/calendar/converter/CalendarConverter.java
@@ -1,0 +1,24 @@
+package com.umc.puppymode2.domain.calendar.converter;
+
+import com.umc.puppymode2.domain.calendar.dto.CalendarResponseDTO;
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class CalendarConverter {
+    public static CalendarResponseDTO toCalendarResponseDTO(DrinkHistory entity) {
+        return CalendarResponseDTO.builder()
+                .date(entity.getDrinkDate())
+                .isDrink(entity.getIsDrink())
+                .build();
+    }
+
+    public static List<CalendarResponseDTO> toCalendarResponseDTOList(List<DrinkHistory> entities) {
+        return entities.stream()
+                .map(CalendarConverter::toCalendarResponseDTO)
+                .collect(Collectors.toList());
+    }
+
+
+}

--- a/src/main/java/com/umc/puppymode2/domain/calendar/dto/CalendarResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/calendar/dto/CalendarResponseDTO.java
@@ -1,0 +1,18 @@
+package com.umc.puppymode2.domain.calendar.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CalendarResponseDTO {
+    private LocalDate date;
+
+    @JsonProperty("isDrink")
+    private boolean isDrink;
+}

--- a/src/main/java/com/umc/puppymode2/domain/calendar/service/CalendarQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/calendar/service/CalendarQueryService.java
@@ -1,0 +1,9 @@
+package com.umc.puppymode2.domain.calendar.service;
+
+import com.umc.puppymode2.domain.calendar.dto.CalendarResponseDTO;
+
+import java.util.List;
+
+public interface CalendarQueryService {
+    List<CalendarResponseDTO> getCalendar(Long userId, int year, int month);
+}

--- a/src/main/java/com/umc/puppymode2/domain/calendar/service/CalendarQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/calendar/service/CalendarQueryServiceImpl.java
@@ -1,0 +1,33 @@
+package com.umc.puppymode2.domain.calendar.service;
+
+import com.umc.puppymode2.domain.calendar.converter.CalendarConverter;
+import com.umc.puppymode2.domain.calendar.dto.CalendarResponseDTO;
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CalendarQueryServiceImpl implements CalendarQueryService {
+
+    private final DrinkHistoryRepository drinkHistoryRepository;
+
+    @Override
+    public List<CalendarResponseDTO> getCalendar(Long userId, int year, int month) {
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        List<DrinkHistory> drinkHistories = drinkHistoryRepository
+                .findAllByUserIdAndDrinkDateBetween(userId, startDate, endDate);
+
+        return CalendarConverter.toCalendarResponseDTOList(drinkHistories);
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -6,8 +6,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
     boolean existsByUserIdAndDrinkDate(Long userId, LocalDate date);
+    List<DrinkHistory> findAllByUserIdAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -17,7 +17,10 @@ public enum SuccessStatus implements BaseCode {
     TEMP_OK(HttpStatus.OK, "TEMP200", "임시 데이터 조회 성공"),
 
     // 로그인
-    KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "카카오 로그인 성공");
+    KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "AUTH200", "카카오 로그인 성공"),
+
+    // 캘린더 조회
+    CALENDAR_GET_SUCCESS(HttpStatus.OK, "CALENDAR200", "캘린더 조회 성공");
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
캘린더 조회 API

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #22

## 🔍 작업 내용  
- 캘린더 조회 API

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 연도와 월을 지정하여 자신의 캘린더 음수 기록을 조회할 수 있는 캘린더 조회 API가 추가되었습니다.
  * 조회 결과는 날짜별 음수 여부가 포함된 리스트 형태로 제공됩니다.

* **기타**
  * 캘린더 조회 성공 시 새로운 성공 메시지가 응답에 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->