### PR TITLE
[FEAT] 음주 리포트 API 로직 완성 #30

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -3,6 +3,8 @@ package com.umc.puppymode2.domain.drinkhistory.repository;
 
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
@@ -12,4 +14,9 @@ import java.util.List;
 public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long> {
     boolean existsByUserUserIdAndDrinkDate(Long userId, LocalDate date);
     List<DrinkHistory> findAllByUserUserIdAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
+    long countByUserUserIdAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
+    @Query("SELECT COUNT(DISTINCT d.drinkDate) FROM DrinkHistory d WHERE d.user.userId = :userId AND d.drinkDate BETWEEN :start AND :end")
+    long countDistinctDrinkDates(@Param("userId") Long userId,
+                                 @Param("start") LocalDate start,
+                                 @Param("end") LocalDate end);
 }

--- a/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import com.umc.puppymode2.global.auth.context.UserContext;
 
 @RestController
 @RequestMapping("/report")
@@ -17,12 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DrinkReportController {
 
     private final DrinkReportService drinkReportService;
-    private final SecurityUserContext securityUserContext;
+    private final UserContext userContext;
 
     @GetMapping
     @Operation(summary = "목표 리포트 API", description = "목표 리포트 조회 API 입니다.")
     public ResponseEntity<ApiResponse<DrinkReportResponseDTO>> getDrinkReport() {
-        Long userId = securityUserContext.getCurrentUserId();
+        Long userId = userContext.getCurrentUserId();
         DrinkReportResponseDTO response = drinkReportService.drinkReport(userId);
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(response, "REPORT200","음주 리포트 조회 성공" )

--- a/src/main/java/com/umc/puppymode2/domain/report/converter/DrinkReportConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/converter/DrinkReportConverter.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DrinkReportConverter {
-    public DrinkReportResponseDTO toDto(Integer goal, Integer drinkCount, Integer drinkDays, Integer achievementRate, Integer scoldedCount) {
+    public DrinkReportResponseDTO toDto(Integer goal, Long drinkCount, Long drinkDays, Integer achievementRate, Integer scoldedCount) {
         return DrinkReportResponseDTO.builder()
                 .goal(goal)
                 .drinkRecordCount(drinkCount)

--- a/src/main/java/com/umc/puppymode2/domain/report/dto/DrinkReportResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/dto/DrinkReportResponseDTO.java
@@ -9,8 +9,8 @@ import lombok.*;
 @Builder
 public class DrinkReportResponseDTO {
     private Integer goal;
-    private Integer drinkRecordCount;
-    private Integer drinkDays;
-    private Integer achievementRate;
-    private Integer scoldedCount;
+    private Long drinkRecordCount;
+    private Long drinkDays;
+    private int achievementRate;
+    private int scoldedCount;
 }

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -1,5 +1,6 @@
 package com.umc.puppymode2.domain.report.service;
 
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
@@ -14,7 +15,7 @@ import java.time.LocalDate;
 @RequiredArgsConstructor
 public class DrinkReportServiceImpl implements DrinkReportService {
     private final UserGoalHistoryRepository userGoalHistoryRepository;
-    // private final DrinkHistoryRepository drinkHistoryRepository; 음주 기록이 나오면 추가
+    private final DrinkHistoryRepository drinkHistoryRepository;
     private final DrinkReportConverter drinkReportConverter;
 
     @Transactional
@@ -29,11 +30,17 @@ public class DrinkReportServiceImpl implements DrinkReportService {
                 .orElse(15); // 기본값 15
 
         // 임시 값. 음주기록 구현되면 하기.
-        int drinkRecordCount = 0;
+        Long drinkRecordCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDayOfMonth, lastDayOfMonth);
 
-        int drinkDays = 0;
+        Long drinkDays = drinkHistoryRepository.countDistinctDrinkDates(userId, firstDayOfMonth, lastDayOfMonth);
 
         int achievementRate = 0;
+        // 음주 횟수가 이번 달 목표를 넘겼으면 확률 0
+        if (drinkDays >= goal){
+            achievementRate = 0;
+        }else{
+            achievementRate = (int) (((double)(goal - drinkDays) / goal) * 100);
+        }
 
         int scoldedCount = 0;
 
@@ -41,8 +48,4 @@ public class DrinkReportServiceImpl implements DrinkReportService {
 
         return dto;
     }
-
-    // 리포트 관련 로직 계산 -> 음주 기록 후
-
-
 }


### PR DESCRIPTION
# 🚀 PR 개요  
음주 리포트에서 목표달성및 음주기록관련 로직 구현했습니다.

## 🔗 관련 이슈  
Closes #30

## 🔍 작업 내용  
- 음주 리포트 로직 완성

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 음주 리포트의 음주 기록 수 및 음주 일수 계산이 실제 데이터 기반으로 개선되었습니다.
  * 음주 리포트 응답에서 일부 필드의 데이터 타입이 변경되어 더 큰 수치와 안정적인 처리가 가능합니다.
  * 사용자 정보 조회 방식이 개선되어 더욱 안정적으로 리포트가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->