### PR TITLE
[BUG] OIDC 인증을 위한 permission 설정 추가 #41

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -7,6 +7,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
     steps:
 
       #------------------- CI --------------------


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- GitHub Actions에서 OIDC로 인증하기 위한 permission 설정 누락

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #41 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI/CD 파이프라인의 보안 권한 구성을 업데이트하여 배포 작업의 인증 및 권한 부여 절차를 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->