### PR TITLE
[BUG] 헬스체크 경로 미인증 허용 #45

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
@@ -41,6 +41,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> {
                     auth.requestMatchers(AUTH_WHITELIST).permitAll();
                     auth.requestMatchers(SWAGGER_WHITELIST).permitAll();
+                    auth.requestMatchers("/actuator/health").permitAll(); // 헬스체크 경로 허용 (취약점은 추후 고려 예정)
                     auth.anyRequest().authenticated();
                 })
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 타겟그룹을 헬스체크하는 경로에 대해서도 보안인증을 요구하다보니, unhealthy라고 판단되는 상황 발생
- SecurityConfig에 `auth.requestMatchers("/actuator/health").permitAll();` 코드 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #45 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * "/actuator/health" 엔드포인트에 인증 없이 접근할 수 있도록 보안 설정이 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->