### PR TITLE
[BUG] JwtAuthenticationFilter에서 헬스체크 경로 허용 #47

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/umc/puppymode2/global/security/JwtAuthenticationFilter.java
@@ -29,6 +29,16 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(@NonNull HttpServletRequest request,
                                     @NonNull HttpServletResponse response,
                                     @NonNull FilterChain filterChain) throws ServletException, IOException {
+
+        String requestURI = request.getRequestURI();
+
+        // 헬스체크 경로는 필터 자체를 스킵
+        if (requestURI.equals("/actuator/health")) {
+            log.info("[JwtAuthenticationFilter] 요청된 헬스체크(/actuator/health)에 대한 필터 검증을 건너뜁니다.");
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         try {
             final String token = getJwtFromRequest(request);
 //            log.debug("Extracted JWT: {}", token);


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- SecurityConfig에서 permitall해줬음에도 여전히 문제 발생 -> 필터에 헬스체크 요청이 닿긴 하는 바람에 unhealthy로 판단되는 것일지도 혹시모르니, JWTFilter 단에서 허용해줘보기로 함.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #47 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * "/actuator/health" 경로에 대한 요청 시 JWT 인증 절차를 건너뛰도록 개선되어, 헬스 체크 요청이 정상적으로 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->