### PR TITLE
[FEAT] 온보딩 검사 API에 userId 반영 #53

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/controller/OnboardingController.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestReqDTO;
 import com.umc.puppymode2.domain.onboarding.dto.OnboardingTestResDTO;
 import com.umc.puppymode2.domain.onboarding.service.OnboardingTestService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.auth.context.UserContext;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -17,6 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/onboarding")
 public class OnboardingController {
 
+    private final UserContext userContext;
     private final OnboardingTestService onboardingTestService;
 
     @PostMapping("/test")
@@ -24,6 +26,7 @@ public class OnboardingController {
     public ApiResponse<OnboardingTestResDTO> recommendAndCreatePuppy(
             @Valid @RequestBody OnboardingTestReqDTO onboardingTestReqDTO) {
 
-        return ApiResponse.onSuccess(onboardingTestService.recommendAndCreatePuppy(onboardingTestReqDTO));
+        Long userId = userContext.getCurrentUserId();
+        return ApiResponse.onSuccess(onboardingTestService.recommendAndCreatePuppy(userId, onboardingTestReqDTO));
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -8,6 +8,8 @@ import com.umc.puppymode2.domain.puppy.entity.PuppyLevel;
 import com.umc.puppymode2.domain.puppy.entity.PuppyType;
 import com.umc.puppymode2.domain.puppy.repository.PuppyLevelRepository;
 import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.exception.handler.TempHandler;
 import lombok.RequiredArgsConstructor;
@@ -24,10 +26,14 @@ import java.util.Set;
 @RequiredArgsConstructor
 public class OnboardingTestService {
 
+    private final UserRepository userRepository;
     private final PuppyRepository puppyRepository;
     private final PuppyLevelRepository puppyLevelRepository;
 
-    public OnboardingTestResDTO recommendAndCreatePuppy(OnboardingTestReqDTO onboardingTestReqDTO) {
+    public OnboardingTestResDTO recommendAndCreatePuppy(Long userId, OnboardingTestReqDTO onboardingTestReqDTO) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new TempHandler(ErrorStatus.USER_NOT_FOUND));
 
         // 올바른 reqDTO 형식인지 검증 후, 각 유형 점수에 해당하는 변수 초기화
         validOnboardingTestReqDTO(onboardingTestReqDTO);
@@ -70,7 +76,7 @@ public class OnboardingTestService {
 
         // Puppy 객체 생성 및 저장
         Puppy puppy = Puppy.builder()
-//                .user(user)
+                .user(user)
                 .puppyLevel(level1)
                 .puppyName(level1.getPuppyType().getBreed())
                 .puppyExp(0)


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 온보딩 검사 API 로직 속 강아지 생성 과정에서 userId 매핑 기능 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #53 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 온보딩 테스트로 생성·추천되는 강아지가 현재 로그인한 사용자 계정에 자동으로 연결됩니다.
  * 생성된 강아지의 소유자 정보가 마이페이지 등 사용자 화면에서 일관되게 표시됩니다.
  * 사용자 식별을 자동 처리하여 요청 흐름이 간소화되고, 계정 기반 개인화가 강화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->