### PR TITLE
[BUG] 탈퇴 사용자의 재가입을 허용하도록 상태 복구 로직 구현 #57

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -79,9 +79,13 @@ public class UserAuthServiceImpl implements UserAuthService {
         Optional<User> optionalUser = userRepository.findByEmail(email);
 
         user = optionalUser.map(existingUser -> {
-            // 탈퇴한 회원인 경우
+            // 탈퇴한 회원인 경우 -> 재활성화 처리
             if (existingUser.getStatus() == UserStatus.STOP) {
-                throw new GeneralException(ErrorStatus.USER_ALREADY_WITHDRAWN);
+
+                // 상태를 NORMAL로 복구
+                existingUser.setStatus(UserStatus.NORMAL);
+
+                return userRepository.save(existingUser);
             }
             return existingUser;
         }).orElseGet(() -> {


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
탈퇴한 사용자의 재로그인 시 발생하던 500 에러를 수정하여 재가입을 허용합니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #57 

## 🔍 작업 내용  
- UserAuthServiceImpl에서 탈퇴 사용자면 GeneralException 발생하는 로직 제거
- UserStatus.STOP → UserStatus.NORMAL로 상태 변경하여 계정 재활성화 처리
- 탈퇴 후 재로그인 시 기존 계정을 복구하는 방식으로 구현

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
@eldeoddt 기존에는 탈퇴한 회원의 경우 에러를 던져 처리했으나, 탈퇴한 사용자의 재가입을 허용하도록 변경했습니다. 재가입 방식은 기존 계정을 재활성화(UserStatus.STOP -> NORMAL)하는 방식으로 구현했고, 탈퇴 시 삭제된 Social Auth는 로그인 과정에서 자동으로 재생성됩니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 정지(STOP) 상태였던 계정이 로그인 시 자동으로 정상(NORMAL) 상태로 복구되어 즉시 서비스 이용이 가능합니다.
  * 신규 가입 여부 표시는 기존과 동일하며, 로그인·인증 및 토큰 발급 흐름은 변함없이 진행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->