### PR TITLE
[FIX] 임시 refresh token 비활성화 #59

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -1,106 +1,106 @@
-package com.umc.puppymode2.domain.user.auth.controller;
-
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenRequestDTO;
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenResponseDTO;
-import com.umc.puppymode2.global.apiPayload.ApiResponse;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
-import com.umc.puppymode2.global.auth.context.UserContext;
-import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
-import com.umc.puppymode2.global.auth.token.JwtTokenService;
-import com.umc.puppymode2.global.exception.GeneralException;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-
-@Slf4j
-@RequiredArgsConstructor
-@RestController
-@RequestMapping("/auth")
-@Tag(name = "Auth", description = "인증 관련 API")
-public class AuthController {
-
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtTokenService jwtTokenService;
-    private final UserContext userContext;
-
-    /**
-     * refresh token 기반 토큰 재발급
-     * <p>
-     * - refresh 토큰을 보내면 저장된 것과 일치하는지 확인합니다.
-     * - 일치할 경우 access + refresh token을 재발급합니다.
-     * - 기존 refresh token은 무효화하고, 새 refresh token으로 덮어씁니다.
-     *
-     * @param dto ReissueTokenRequestDTO
-     * @return new access + refresh token
-     */
-    @Operation(
-            summary = "토큰 재발급",
-            description = "Refresh Token을 기반으로 Access/Refresh Token을 재발급합니다."
-    )
-    @PostMapping("/reissue")
-    public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
-
-        String incomingRefreshToken = dto.refreshToken();
-
-        Long userId = userContext.getCurrentUserId();
-        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
-
-        // 상수 시간 비교
-        if (savedRefreshToken == null || !MessageDigest.isEqual(
-                savedRefreshToken.getBytes(StandardCharsets.UTF_8), // 인코딩 형식 통일
-                incomingRefreshToken.getBytes(StandardCharsets.UTF_8)
-        )) {
-            log.warn("[REISSUE] 유효하지 않은 Refresh Token - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        // refresh token 교체
-        String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
-        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
-        jwtTokenService.saveRefreshToken(userId, newRefreshToken);
-
-        Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
-        log.info("[REISSUE] Refresh Token 재발급 완료 - userId={}", userId);
-
-        return ApiResponse.onSuccess(
-                new ReissueTokenResponseDTO(newAccessToken, newRefreshToken, expiresIn),
-                SuccessStatus.AUTH_REISSUE_SUCCESS.getCode(),
-                SuccessStatus.AUTH_REISSUE_SUCCESS.getMessage()
-        );
-    }
-
-    /**
-     * 로그아웃 처리를 합니다. (저장된 refresh token 삭제)
-     */
-    @Operation(
-            summary = "로그아웃",
-            description = "현재 로그인된 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다."
-    )
-    @PostMapping("/logout")
-    public ApiResponse<Void> logout() {
-
-        Long userId = userContext.getCurrentUserId();
-        boolean result = jwtTokenService.removeRefreshToken(userId);
-
-        if (result) {
-            log.info("[LOGOUT] RefreshToken 삭제 완료 - userId={}", userId);
-        } else {
-            log.info("[LOGOUT] 삭제할 RefreshToken이 없음 - userId={}", userId);
-        }
-
-        return ApiResponse.onSuccess(
-                null,
-                SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
-                SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
-        );
-    }
-}
+//package com.umc.puppymode2.domain.user.auth.controller;
+//
+//import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenRequestDTO;
+//import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenResponseDTO;
+//import com.umc.puppymode2.global.apiPayload.ApiResponse;
+//import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+//import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+//import com.umc.puppymode2.global.auth.context.UserContext;
+//import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
+//import com.umc.puppymode2.global.auth.token.JwtTokenService;
+//import com.umc.puppymode2.global.exception.GeneralException;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import java.nio.charset.StandardCharsets;
+//import java.security.MessageDigest;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@RestController
+//@RequestMapping("/auth")
+//@Tag(name = "Auth", description = "인증 관련 API")
+//public class AuthController {
+//
+//    private final JwtTokenProvider jwtTokenProvider;
+//    private final JwtTokenService jwtTokenService;
+//    private final UserContext userContext;
+//
+//    /**
+//     * refresh token 기반 토큰 재발급
+//     * <p>
+//     * - refresh 토큰을 보내면 저장된 것과 일치하는지 확인합니다.
+//     * - 일치할 경우 access + refresh token을 재발급합니다.
+//     * - 기존 refresh token은 무효화하고, 새 refresh token으로 덮어씁니다.
+//     *
+//     * @param dto ReissueTokenRequestDTO
+//     * @return new access + refresh token
+//     */
+//    @Operation(
+//            summary = "토큰 재발급",
+//            description = "Refresh Token을 기반으로 Access/Refresh Token을 재발급합니다."
+//    )
+//    @PostMapping("/reissue")
+//    public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
+//
+//        String incomingRefreshToken = dto.refreshToken();
+//
+//        Long userId = userContext.getCurrentUserId();
+//        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
+//
+//        // 상수 시간 비교
+//        if (savedRefreshToken == null || !MessageDigest.isEqual(
+//                savedRefreshToken.getBytes(StandardCharsets.UTF_8), // 인코딩 형식 통일
+//                incomingRefreshToken.getBytes(StandardCharsets.UTF_8)
+//        )) {
+//            log.warn("[REISSUE] 유효하지 않은 Refresh Token - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        // refresh token 교체
+//        String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
+//        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
+//        jwtTokenService.saveRefreshToken(userId, newRefreshToken);
+//
+//        Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
+//        log.info("[REISSUE] Refresh Token 재발급 완료 - userId={}", userId);
+//
+//        return ApiResponse.onSuccess(
+//                new ReissueTokenResponseDTO(newAccessToken, newRefreshToken, expiresIn),
+//                SuccessStatus.AUTH_REISSUE_SUCCESS.getCode(),
+//                SuccessStatus.AUTH_REISSUE_SUCCESS.getMessage()
+//        );
+//    }
+//
+//    /**
+//     * 로그아웃 처리를 합니다. (저장된 refresh token 삭제)
+//     */
+//    @Operation(
+//            summary = "로그아웃",
+//            description = "현재 로그인된 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다."
+//    )
+//    @PostMapping("/logout")
+//    public ApiResponse<Void> logout() {
+//
+//        Long userId = userContext.getCurrentUserId();
+//        boolean result = jwtTokenService.removeRefreshToken(userId);
+//
+//        if (result) {
+//            log.info("[LOGOUT] RefreshToken 삭제 완료 - userId={}", userId);
+//        } else {
+//            log.info("[LOGOUT] 삭제할 RefreshToken이 없음 - userId={}", userId);
+//        }
+//
+//        return ApiResponse.onSuccess(
+//                null,
+//                SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
+//                SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
+//        );
+//    }
+//}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -140,11 +140,11 @@ public class UserAuthServiceImpl implements UserAuthService {
         Long userId = user.getUserId();
 
         String accessToken = jwtTokenProvider.generateAccessToken(userId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+//        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
         Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
 
         // Redis에 refresh token 저장
-        jwtTokenService.saveRefreshToken(userId, refreshToken);
+//        jwtTokenService.saveRefreshToken(userId, refreshToken);
 
         log.info("[LOGIN] 토큰 발급 완료 - userId={}", userId);
 
@@ -156,7 +156,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         return LoginResponseDTO.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .refreshToken(null) //todo: refreshtoken으로 변경
                 .expiresIn(expiresIn)
                 .userInfo(loginUserInfo)
                 .build();

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -1,115 +1,115 @@
-package com.umc.puppymode2.global.config;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.exception.GeneralException;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
-
-@Slf4j
-@Configuration
-@EnableCaching
-public class RedisConfig {
-
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
-
-    @Value("${spring.data.redis.timeout}")
-    private Duration timeout;
-
-    @Value("${spring.data.redis.ssl:false}")
-    private boolean sslEnabled;
-
-    /**
-     * LettuceClientFactory 생성
-     * - ssl 사용
-     * - password 설정
-     * - connection timeout 지정
-     *
-     * @return
-     */
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(host);
-        config.setPort(port);
-
-        if (password != null && !password.isBlank()) {
-            config.setPassword(password);
-        }
-
-        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
-                LettuceClientConfiguration.builder()
-                        .commandTimeout(timeout)
-                        .shutdownTimeout(Duration.ofMillis(100));
-
-        // 환경에 따라 TLS 적용
-        if (sslEnabled) {
-            builder.useSsl();
-        }
-
-        LettuceClientConfiguration clientConfiguration = builder.build();
-
-        return new LettuceConnectionFactory(config, clientConfiguration);
-    }
-
-    /**
-     * RedisTemplate 설정
-     * - Key: String
-     * - Value: Json 직렬화
-     * - HashKey: String
-     * - HashValue: Json 직렬화
-     *
-     * @param connectionFactory
-     * @param objectMapper
-     * @return
-     */
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory,
-                                                       ObjectMapper objectMapper) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        // Key 직렬화
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-
-        // Value 직렬화
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
-
-        template.afterPropertiesSet();
-        return template;
-    }
-
-    @Bean
-    public CommandLineRunner safeRedisCheck(LettuceConnectionFactory cf) {
-        return args -> {
-            try {
-                log.info("[REDIS] {}", cf.getConnection().ping());
-            } catch (Exception e) {
-                log.warn("[REDIS] 초기 연결 실패 {}", e.getMessage());
-                throw new IllegalStateException("Redis 연결 실패 - 애플리케이션 중단", e);
-            }
-        };
-    }
-}
+//package com.umc.puppymode2.global.config;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+//import com.umc.puppymode2.global.exception.GeneralException;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.cache.annotation.EnableCaching;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.redis.connection.RedisConnectionFactory;
+//import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+//import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+//import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
+//
+//import java.time.Duration;
+//
+//@Slf4j
+//@Configuration
+//@EnableCaching
+//public class RedisConfig {
+//
+//    @Value("${spring.data.redis.host}")
+//    private String host;
+//
+//    @Value("${spring.data.redis.port}")
+//    private int port;
+//
+//    @Value("${spring.data.redis.password}")
+//    private String password;
+//
+//    @Value("${spring.data.redis.timeout}")
+//    private Duration timeout;
+//
+//    @Value("${spring.data.redis.ssl:false}")
+//    private boolean sslEnabled;
+//
+//    /**
+//     * LettuceClientFactory 생성
+//     * - ssl 사용
+//     * - password 설정
+//     * - connection timeout 지정
+//     *
+//     * @return
+//     */
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+//        config.setHostName(host);
+//        config.setPort(port);
+//
+//        if (password != null && !password.isBlank()) {
+//            config.setPassword(password);
+//        }
+//
+//        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
+//                LettuceClientConfiguration.builder()
+//                        .commandTimeout(timeout)
+//                        .shutdownTimeout(Duration.ofMillis(100));
+//
+//        // 환경에 따라 TLS 적용
+//        if (sslEnabled) {
+//            builder.useSsl();
+//        }
+//
+//        LettuceClientConfiguration clientConfiguration = builder.build();
+//
+//        return new LettuceConnectionFactory(config, clientConfiguration);
+//    }
+//
+//    /**
+//     * RedisTemplate 설정
+//     * - Key: String
+//     * - Value: Json 직렬화
+//     * - HashKey: String
+//     * - HashValue: Json 직렬화
+//     *
+//     * @param connectionFactory
+//     * @param objectMapper
+//     * @return
+//     */
+//    @Bean
+//    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory,
+//                                                       ObjectMapper objectMapper) {
+//        RedisTemplate<String, Object> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//
+//        // Key 직렬화
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setHashKeySerializer(new StringRedisSerializer());
+//
+//        // Value 직렬화
+//        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+//        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+//
+//        template.afterPropertiesSet();
+//        return template;
+//    }
+//
+//    @Bean
+//    public CommandLineRunner safeRedisCheck(LettuceConnectionFactory cf) {
+//        return args -> {
+//            try {
+//                log.info("[REDIS] {}", cf.getConnection().ping());
+//            } catch (Exception e) {
+//                log.warn("[REDIS] 초기 연결 실패 {}", e.getMessage());
+//                throw new IllegalStateException("Redis 연결 실패 - 애플리케이션 중단", e);
+//            }
+//        };
+//    }
+//}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
임시로 서버 활성화를 위해 redis를 비활성화 했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 인증 엔드포인트(토큰 재발급, 로그아웃) 비활성화
  - 로그인 시 액세스 토큰만 발급되며 리프레시 토큰은 제공되지 않음

- Chores
  - Redis 기반 구성 비활성화로 자동 로그인/세션 유지 동작이 변경될 수 있음
  - 토큰 재발급 흐름 중단에 따라 세션 만료 시 재로그인이 필요할 수 있음

<!-- end of auto-generated comment: release notes by coderabbit.ai -->