### PR TITLE
[BUG] build.gradle의 redis 의존성 임시 제거 #63

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,8 +53,8 @@ dependencies {
     // Spring Actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
-    // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    // redis
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 jar {

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -1,17 +1,15 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
+import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.domain.user.auth.enums.Provider;
 import com.umc.puppymode2.domain.user.entity.SocialAuth;
 import com.umc.puppymode2.domain.user.entity.User;
 import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
 import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
-import com.umc.puppymode2.domain.user.auth.enums.Provider;
 import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
-import com.umc.puppymode2.global.auth.token.JwtTokenService;
-import com.umc.puppymode2.global.exception.GeneralException;
+//import com.umc.puppymode2.global.auth.token.JwtTokenService;
 import com.umc.puppymode2.global.security.UserAuthentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,7 +30,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final JwtTokenService jwtTokenService;
+//    private final JwtTokenService jwtTokenService;
     private final SocialAuthRepository socialAuthRepository;
 
     @Transactional

--- a/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenService.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenService.java
@@ -1,97 +1,97 @@
-package com.umc.puppymode2.global.auth.token;
-
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.exception.GeneralException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-
-@Slf4j
-@RequiredArgsConstructor
-@Service
-public class JwtTokenService {
-
-    private static final String PREFIX = "RT";
-    private final RedisTemplate<String, String> redisTemplate;
-
-    private final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(14);
-
-    /**
-     * Refresh Token을 Redis에 저장합니다.
-     * <p>
-     * - key: "RT:{userId}"
-     * - value: refreshToken
-     * - TTL: 14일
-     *
-     * @param userId
-     * @param refreshToken
-     */
-    public void saveRefreshToken(Long userId, String refreshToken) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        if (refreshToken == null || refreshToken.trim().isEmpty()) {
-            log.warn("[REDIS] No refresh token is null - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        String key = buildKey(userId);
-
-        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRY);
-        log.info("[REDIS] Saved refresh token - userId={}", userId);
-    }
-
-    /**
-     * Redis에서 유저의 refresh token을 조회합니다.
-     *
-     * @param userId
-     * @return
-     */
-    public String getRefreshToken(Long userId) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        String key = buildKey(userId);
-        String token = redisTemplate.opsForValue().get(key);
-
-        if (token == null) {
-            log.warn("[REDIS] No refresh token is null - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        return token;
-    }
-
-    /**
-     * Redis에서 해당 유저의 refresh token을 제거합니다.
-     * <p>
-     * - 로그아웃 또는 강제 만료 시 호출됩니다.
-     *
-     * @param userId
-     */
-    public boolean removeRefreshToken(Long userId) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        String key = buildKey(userId);
-        Boolean result = redisTemplate.delete(key);
-
-        boolean isDeleted = Boolean.TRUE.equals(result);
-        log.info("[REDIS] Removed refresh token - result : {} - userId={}", isDeleted, userId);
-
-        return isDeleted;
-    }
-
-    private String buildKey(Long userId) {
-        return PREFIX + userId;
-    }
-}
+//package com.umc.puppymode2.global.auth.token;
+//
+//import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+//import com.umc.puppymode2.global.exception.GeneralException;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.Duration;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@Service
+//public class JwtTokenService {
+//
+//    private static final String PREFIX = "RT";
+//    private final RedisTemplate<String, String> redisTemplate;
+//
+//    private final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(14);
+//
+//    /**
+//     * Refresh Token을 Redis에 저장합니다.
+//     * <p>
+//     * - key: "RT:{userId}"
+//     * - value: refreshToken
+//     * - TTL: 14일
+//     *
+//     * @param userId
+//     * @param refreshToken
+//     */
+//    public void saveRefreshToken(Long userId, String refreshToken) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        if (refreshToken == null || refreshToken.trim().isEmpty()) {
+//            log.warn("[REDIS] No refresh token is null - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        String key = buildKey(userId);
+//
+//        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRY);
+//        log.info("[REDIS] Saved refresh token - userId={}", userId);
+//    }
+//
+//    /**
+//     * Redis에서 유저의 refresh token을 조회합니다.
+//     *
+//     * @param userId
+//     * @return
+//     */
+//    public String getRefreshToken(Long userId) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        String key = buildKey(userId);
+//        String token = redisTemplate.opsForValue().get(key);
+//
+//        if (token == null) {
+//            log.warn("[REDIS] No refresh token is null - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        return token;
+//    }
+//
+//    /**
+//     * Redis에서 해당 유저의 refresh token을 제거합니다.
+//     * <p>
+//     * - 로그아웃 또는 강제 만료 시 호출됩니다.
+//     *
+//     * @param userId
+//     */
+//    public boolean removeRefreshToken(Long userId) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        String key = buildKey(userId);
+//        Boolean result = redisTemplate.delete(key);
+//
+//        boolean isDeleted = Boolean.TRUE.equals(result);
+//        log.info("[REDIS] Removed refresh token - result : {} - userId={}", isDeleted, userId);
+//
+//        return isDeleted;
+//    }
+//
+//    private String buildKey(Long userId) {
+//        return PREFIX + userId;
+//    }
+//}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- `Unable to connect to localhost/<unresolved>:6379`과 같은 에러 로그 발생
- springboot에서 redis로의 연결 시도 자체를 비활성화 해야함
->build.gradle의 redis 의존성 제거

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 해당 버전에는 신규 기능 추가가 없습니다.
- 리팩터링
  - 토큰 관리 연동을 비활성화해 인증 흐름을 단순화했습니다. 자동 토큰 갱신/세션 연장이 제한될 수 있어, 더 자주 재로그인이 필요할 수 있습니다. 기존 로그인/로그아웃은 정상 동작합니다.
- 작업(Chores)
  - 외부 캐시/데이터 저장소 의존성을 비활성화하여 배포 구성을 단순화했습니다. 공개 인터페이스 변화는 없습니다. 성능과 자원 사용이 소폭 개선될 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->