### PR TITLE
[FEAT] Dockerfile에 JVM 옵션 추가 #65

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,5 @@ FROM eclipse-temurin:17-jdk
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar
 VOLUME /tmp
-ENTRYPOINT ["java", "-jar", "app.jar"]
+ENV JAVA_OPTS="-Xms200m -Xmx400m -XX:+UseG1GC"
+ENTRYPOINT ["sh", "-c", "java $JAVA_OPTS -jar /app.jar"]


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 새로운 task definition 배포 시에, service memory utilization이 90 가까이 찍고, 배포된 task 자꾸 종료되는 현상 발생
-> OutOfMemory나 Memory spike 방지하고자, Spring Boot 컨테이너의 JVM 힙을 Task Memory보다 적게 제한하도록 옵션 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #65 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  * 컨테이너 실행 시 JAVA_OPTS 환경 변수로 JVM 옵션을 동적으로 설정할 수 있습니다(메모리, GC 등).
* 사소한 변경
  * 기본 JAVA_OPTS 값을 제공합니다(-Xms200m, -Xmx400m, -XX:+UseG1GC).
  * 컨테이너 시작 방식이 셸을 통해 java를 호출하도록 업데이트되어 실행 옵션 커스터마이징이 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->