### PR TITLE
[REFACTOR] 음주 리포트 해당 월 표기 수정 #68

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -3,11 +3,13 @@ package com.umc.puppymode2.domain.goal.repository;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 @Repository
 public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory, Long> {
     Optional<UserGoalHistory> findTopByUserIdOrderByGoalSetAtDesc(Long userId);
+    Optional<UserGoalHistory> findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(
+            Long userId, LocalDateTime asOfDate
+    );
 }

--- a/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
@@ -3,14 +3,18 @@ package com.umc.puppymode2.domain.report.controller;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
 import com.umc.puppymode2.domain.report.service.DrinkReportService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
-import com.umc.puppymode2.global.auth.context.SecurityUserContext;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import com.umc.puppymode2.global.auth.context.UserContext;
+import java.time.YearMonth;
 
 @RestController
 @RequestMapping("/report")
@@ -21,10 +25,19 @@ public class DrinkReportController {
     private final UserContext userContext;
 
     @GetMapping
-    @Operation(summary = "목표 리포트 API", description = "목표 리포트 조회 API 입니다.")
-    public ResponseEntity<ApiResponse<DrinkReportResponseDTO>> getDrinkReport() {
+    @Operation(summary = "목표 리포트 API", description = "선택 월(yyyy-MM) 기준으로 음주 리포트를 조회합니다. 예: 2025-08")
+    public ResponseEntity<ApiResponse<DrinkReportResponseDTO>> getDrinkReport(
+            @Parameter(description = "조회 연도 (예: 2025)", example = "2025")
+            @RequestParam(name = "year") @Min(2000) @Max(2100) int year,
+
+            @Parameter(description = "조회 월 (1~12)", example = "10")
+            @RequestParam(name = "month") @Min(1) @Max(12) int month
+    ) {
         Long userId = userContext.getCurrentUserId();
-        DrinkReportResponseDTO response = drinkReportService.drinkReport(userId);
+
+        YearMonth targetMonth = YearMonth.of(year, month);
+
+        DrinkReportResponseDTO response = drinkReportService.drinkReport(userId, targetMonth);
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(response, "REPORT200","음주 리포트 조회 성공" )
         );

--- a/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/controller/DrinkReportController.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.umc.puppymode2.global.auth.context.UserContext;
 import java.time.YearMonth;
 
+@Validated
 @RestController
 @RequestMapping("/report")
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportService.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportService.java
@@ -1,7 +1,8 @@
 package com.umc.puppymode2.domain.report.service;
 
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import java.time.YearMonth;
 
 public interface DrinkReportService {
-    DrinkReportResponseDTO drinkReport(Long userId);
+    DrinkReportResponseDTO drinkReport(Long userId, YearMonth targetMonth);
 }

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -10,6 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.YearMonth;
 
 @Service
 @RequiredArgsConstructor
@@ -18,33 +21,37 @@ public class DrinkReportServiceImpl implements DrinkReportService {
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final DrinkReportConverter drinkReportConverter;
 
-    @Transactional
+    @Transactional(Transactional.TxType.SUPPORTS)
     @Override
-    public DrinkReportResponseDTO drinkReport(Long userId) {
-        LocalDate now = LocalDate.now();
-        LocalDate firstDayOfMonth = now.withDayOfMonth(1);
-        LocalDate lastDayOfMonth = now.withDayOfMonth(now.lengthOfMonth());
+    public DrinkReportResponseDTO drinkReport(Long userId, YearMonth targetMonth) {
 
-        int goal = userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+        LocalDate firstDayOfMonth = targetMonth.atDay(1);
+        LocalDate lastDayOfMonth = targetMonth.atEndOfMonth();
+
+        // asOf 기준 시간을 LocalDateTime으로 변환 (그 달의 마지막 순간)
+        LocalDateTime asOfDateTime = lastDayOfMonth.atTime(LocalTime.MAX);
+
+        int goal = userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(userId, asOfDateTime)
                 .map(UserGoalHistory::getMonthlyGoalCount)
                 .orElse(15); // 기본값 15
 
-        // 임시 값. 음주기록 구현되면 하기.
-        Long drinkRecordCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDayOfMonth, lastDayOfMonth);
+        long drinkRecordCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDayOfMonth, lastDayOfMonth);
 
-        Long drinkDays = drinkHistoryRepository.countDistinctDrinkDates(userId, firstDayOfMonth, lastDayOfMonth);
+        long drinkDays = drinkHistoryRepository.countDistinctDrinkDates(userId, firstDayOfMonth, lastDayOfMonth);
 
-        int achievementRate = 0;
-        // 음주 횟수가 이번 달 목표를 넘겼으면 확률 0
-        if (drinkDays >= goal){
+        // 절주 목표 유지율! (마신 비율이 아니라, 목표대비 안마신 비율!) 최대한 안마시는게 목표
+        int achievementRate;
+        if (goal <= 0 || drinkDays >= goal) {
             achievementRate = 0;
-        }else{
-            achievementRate = (int) (((double)(goal - drinkDays) / goal) * 100);
+        } else {
+            achievementRate = (int) (((double) (goal - drinkDays) / goal) * 100);
         }
 
+        // TODO : 패널티 횟수 -> 한마디 횟수
         int scoldedCount = 0;
 
-        DrinkReportResponseDTO dto = drinkReportConverter.toDto(goal, drinkRecordCount, drinkDays, achievementRate, scoldedCount);
+        DrinkReportResponseDTO dto = drinkReportConverter.toDto(goal, Long.valueOf(drinkRecordCount), Long.valueOf(drinkDays), achievementRate, scoldedCount);
 
         return dto;
     }


### PR DESCRIPTION
# 🚀 PR 개요  

음주 리포트 관련 QA 수정사항 반영입니다.

기존 : 가장 최근 한달간의 리포트 조회
변경 : 캘린더에서 월 바뀌었을 때 음주 리포트도 해당 월의 음주 리포트 표기

## 🔗 관련 이슈  
Closes #68 

## 🔍 작업 내용  
- 캘린더에서 월 바뀌었을 때 음주 리포트도 해당 월의 음주 리포트 표기

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 음주 리포트를 연도(year)와 월(month) 파라미터로 조회할 수 있게 되어 특정 월의 리포트를 확인할 수 있습니다.

* **개선**
  * 조회 대상 월 기준으로 과거 목표와 집계가 정확히 반영되도록 리포트 계산 로직을 개선했습니다.
  * 연도/월 입력에 기본 범위 검증을 추가해 잘못된 기간 요청을 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->