### PR TITLE
[FEAT] 음주 리포트 이번 달 한마디 들은 횟수 반영 #70

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/advice/entity/Advice.java
+++ b/src/main/java/com/umc/puppymode2/domain/advice/entity/Advice.java
@@ -1,0 +1,37 @@
+package com.umc.puppymode2.domain.advice.entity;
+
+import com.umc.puppymode2.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "advice")
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Advice {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long adviceId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    // 조언 전송 시점 (리포트 카운트 기준)
+    @Column(nullable = false)
+    private LocalDateTime advisedAt;
+
+    @CreationTimestamp
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/umc/puppymode2/domain/advice/repository/AdviceRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/advice/repository/AdviceRepository.java
@@ -1,0 +1,11 @@
+package com.umc.puppymode2.domain.advice.repository;
+
+import com.umc.puppymode2.domain.advice.entity.Advice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+
+public interface AdviceRepository extends JpaRepository<Advice, Long> {
+     // 특정 사용자가 특정 기간 동안 들은 조언(한마디) 횟수를 카운트합니다.
+    long countByUserUserIdAndAdvisedAtBetween(Long userId, LocalDateTime startDate, LocalDateTime endDate);
+}

--- a/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
@@ -8,6 +8,13 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.umc.puppymode2.domain.advice.entity.Advice;
+import com.umc.puppymode2.domain.advice.repository.AdviceRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.LocalDateTime;
+
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -22,6 +29,9 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
     private final UserGoalHistoryRepository userGoalHistoryRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final Random random = new Random();
+
+    private final AdviceRepository adviceRepository;
+    private final UserRepository userRepository;
 
     @Override
     public AdviceResponseDTO getAdvice(Long userId) {
@@ -43,6 +53,9 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
 
         // 조언 메시지 생성
         String advice = getRandomAdvice(goal, actual, recordedYesterday);
+
+        saveAdviceRecord(userId);
+
         return new AdviceResponseDTO(advice);
     }
 
@@ -110,5 +123,18 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
         // 랜덤 셔플 후 하나 선택
         Collections.shuffle(messages);
         return messages.get(random.nextInt(messages.size()));
+    }
+
+    @Transactional
+    private void saveAdviceRecord(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found for ID: " + userId));
+
+        Advice advice = Advice.builder()
+                .user(user)
+                .advisedAt(LocalDateTime.now()) // 현재 시점 기록
+                .build();
+
+        adviceRepository.save(advice);
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.puppymode2.domain.report.service;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.advice.repository.AdviceRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
 import jakarta.transaction.Transactional;
@@ -19,6 +20,7 @@ import java.time.YearMonth;
 public class DrinkReportServiceImpl implements DrinkReportService {
     private final UserGoalHistoryRepository userGoalHistoryRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
+    private final AdviceRepository adviceRepository;
     private final DrinkReportConverter drinkReportConverter;
 
     @Transactional(Transactional.TxType.SUPPORTS)
@@ -28,7 +30,7 @@ public class DrinkReportServiceImpl implements DrinkReportService {
         LocalDate firstDayOfMonth = targetMonth.atDay(1);
         LocalDate lastDayOfMonth = targetMonth.atEndOfMonth();
 
-        // asOf 기준 시간을 LocalDateTime으로 변환 (그 달의 마지막 순간)
+        LocalDateTime startDateTime = firstDayOfMonth.atStartOfDay();
         LocalDateTime asOfDateTime = lastDayOfMonth.atTime(LocalTime.MAX);
 
         int goal = userGoalHistoryRepository
@@ -48,8 +50,8 @@ public class DrinkReportServiceImpl implements DrinkReportService {
             achievementRate = (int) (((double) (goal - drinkDays) / goal) * 100);
         }
 
-        // TODO : 패널티 횟수 -> 한마디 횟수
-        int scoldedCount = 0;
+        int scoldedCount = (int) adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(userId, startDateTime, asOfDateTime);
 
         DrinkReportResponseDTO dto = drinkReportConverter.toDto(goal, Long.valueOf(drinkRecordCount), Long.valueOf(drinkDays), achievementRate, scoldedCount);
 


### PR DESCRIPTION
# 🚀 PR 개요  

QA 수정사항 반영입니다.
- 음주 리포트 이번 달 한마디 들은 횟수 반영

## 🔗 관련 이슈  

Closes #70 

## 🔍 작업 내용  
- Advice 엔티티 및 repository 생성
  - ERD 업데이트
- Advice service에서 한마디 호출시 저장 (구체적 한마디는 저장x)
- Report에서 해당 Advice Repository통해 카운트 값 반영

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
슬랙에 공유한 바에 따라,

"이번 달 한마디 들은 횟수"를 리포트에 반영해야하는데, 
현재 로직이 DB 저장 없이 음주 횟수 등에 따라 랜덤으로 한마디를 생성하고 종료되는 구조입니다.

굳이 한마디를 저장할 필요까지는 지금의 요구사항으로는 없어보이지만, 횟수 카운팅은 따로 DB에 저장해야 카운트를 정확히 할 수 있을 것 같아 간단한 Advice Entity를 추가했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 출시 정보

* **새로운 기능**
  * 사용자별 조언 이력 자동 기록 및 추적 기능 추가
  * 조언 생성 시 정확한 타임스탬프와 함께 저장

* **개선사항**
  * 월간 보고서에서 조언 횟수를 고정값 대신 실제 데이터 기반으로 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->