### PR TITLE
Refactor/#72 drink history exp

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/controller/DrinkHistoryController.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/controller/DrinkHistoryController.java
@@ -1,6 +1,7 @@
 package com.umc.puppymode2.domain.drinkhistory.controller;
 
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryStatusDTO;
 import com.umc.puppymode2.domain.drinkhistory.service.DrinkHistoryCommandService;
 import com.umc.puppymode2.domain.drinkhistory.service.DrinkHistoryQueryService;
@@ -28,11 +29,11 @@ public class DrinkHistoryController {
 
     @Operation(summary = "음주 기록 생성 API", description = "새로운 음주 기록을 생성합니다.")
     @PostMapping
-    public ApiResponse<Long> createDrinkHistory(
+    public ApiResponse<DrinkHistoryResponseDTO> createDrinkHistory(
             @RequestBody @Valid DrinkHistoryRequestDTO request) {
         Long userId = userContext.getCurrentUserId();
-        Long drinkHistoryId = drinkHistoryCommandService.recordDrink(userId, request);
-        return ApiResponse.onSuccess(drinkHistoryId, SuccessStatus.DRINK_HISTORY_RECORD_SUCCESS.getCode(), SuccessStatus.DRINK_HISTORY_RECORD_SUCCESS.getMessage());
+        DrinkHistoryResponseDTO drinkHistoryResponseDTO = drinkHistoryCommandService.recordDrink(userId, request);
+        return ApiResponse.onSuccess(drinkHistoryResponseDTO, SuccessStatus.DRINK_HISTORY_RECORD_SUCCESS.getCode(), SuccessStatus.DRINK_HISTORY_RECORD_SUCCESS.getMessage());
     }
 
     @Operation(summary = "음주 기록 상태 조회 API", description = "어제와 오늘의 음주 기록 상태를 조회합니다.")

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/converter/DrinkHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/converter/DrinkHistoryConverter.java
@@ -1,6 +1,7 @@
 package com.umc.puppymode2.domain.drinkhistory.converter;
 
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryStatusDTO;
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import com.umc.puppymode2.domain.user.entity.User;
@@ -18,6 +19,13 @@ public class DrinkHistoryConverter {
                 .user(user)
                 .isDrink(dto.getIsDrink())
                 .drinkDate(dto.getDrinkDate())
+                .build();
+    }
+
+    public static DrinkHistoryResponseDTO toResponseDTO(Long drinkHistoryId, int puppyExp) {
+        return DrinkHistoryResponseDTO.builder()
+                .drinkHistoryId(drinkHistoryId)
+                .puppyExp(puppyExp)
                 .build();
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/dto/DrinkHistoryResponseDTO.java
@@ -1,0 +1,15 @@
+package com.umc.puppymode2.domain.drinkhistory.dto;
+
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DrinkHistoryResponseDTO {
+    private Long drinkHistoryId;
+    private Integer puppyExp;
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandService.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandService.java
@@ -1,7 +1,8 @@
 package com.umc.puppymode2.domain.drinkhistory.service;
 
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 
 public interface DrinkHistoryCommandService {
-    Long recordDrink(Long userId, DrinkHistoryRequestDTO dto);
+    DrinkHistoryResponseDTO recordDrink(Long userId, DrinkHistoryRequestDTO dto);
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -4,6 +4,8 @@ import com.umc.puppymode2.domain.drinkhistory.converter.DrinkHistoryConverter;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
 import com.umc.puppymode2.domain.user.entity.User;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
@@ -18,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandService {
     private final UserRepository userRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
+    private final PuppyRepository puppyRepository;
 
     @Override
     public Long recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
@@ -29,6 +32,14 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
             throw new IllegalStateException("이미 해당 날짜에 음주 기록이 존재합니다.");
         }
         DrinkHistory drinkHistory = drinkHistoryRepository.save(DrinkHistoryConverter.toEntity(user, dto));
+
+        Puppy puppy = puppyRepository.findByUser_UserId(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+        int updatedExp = puppy.getPuppyExp() + 10;
+        puppy.setPuppyExp(updatedExp);
+
+        puppyRepository.save(puppy);
+
         return drinkHistory.getDrinkHistoryId();
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -2,6 +2,7 @@ package com.umc.puppymode2.domain.drinkhistory.service;
 
 import com.umc.puppymode2.domain.drinkhistory.converter.DrinkHistoryConverter;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
+import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.puppy.entity.Puppy;
@@ -23,7 +24,7 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
     private final PuppyRepository puppyRepository;
 
     @Override
-    public Long recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
+    public DrinkHistoryResponseDTO recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
@@ -40,6 +41,6 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
 
         puppyRepository.save(puppy);
 
-        return drinkHistory.getDrinkHistoryId();
+        return DrinkHistoryConverter.toResponseDTO(drinkHistory.getDrinkHistoryId(), puppy.getPuppyExp());
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
 QA 수정사항 반영
음주 기록 시 경험치가 오르지 않는 문제 수정

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #72

## 🔍 작업 내용  
- 음주 기록 API 경험치 증가 반영
- 음주 기록 시 경험치를 포함한 DTO 반환 수정

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 음수 기록 시 응답에 강아지의 업데이트된 경험치가 포함되도록 개선
  * 음수를 기록할 때마다 강아지가 10 경험치를 획득

* **개선**
  * 음수 기록 API 응답 데이터 구조 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->