### PR TITLE
[BUG] redis 비활성화 #59

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // redis
-    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+//    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 jar {

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -1,106 +1,106 @@
-package com.umc.puppymode2.domain.user.auth.controller;
-
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenRequestDTO;
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenResponseDTO;
-import com.umc.puppymode2.global.apiPayload.ApiResponse;
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
-import com.umc.puppymode2.global.auth.context.UserContext;
-import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
-import com.umc.puppymode2.global.auth.token.JwtTokenService;
-import com.umc.puppymode2.global.exception.GeneralException;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.tags.Tag;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-
-@Slf4j
-@RequiredArgsConstructor
-@RestController
-@RequestMapping("/auth")
-@Tag(name = "Auth", description = "인증 관련 API")
-public class AuthController {
-
-    private final JwtTokenProvider jwtTokenProvider;
-    private final JwtTokenService jwtTokenService;
-    private final UserContext userContext;
-
-    /**
-     * refresh token 기반 토큰 재발급
-     * <p>
-     * - refresh 토큰을 보내면 저장된 것과 일치하는지 확인합니다.
-     * - 일치할 경우 access + refresh token을 재발급합니다.
-     * - 기존 refresh token은 무효화하고, 새 refresh token으로 덮어씁니다.
-     *
-     * @param dto ReissueTokenRequestDTO
-     * @return new access + refresh token
-     */
-    @Operation(
-            summary = "토큰 재발급",
-            description = "Refresh Token을 기반으로 Access/Refresh Token을 재발급합니다."
-    )
-    @PostMapping("/reissue")
-    public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
-
-        String incomingRefreshToken = dto.refreshToken();
-
-        Long userId = userContext.getCurrentUserId();
-        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
-
-        // 상수 시간 비교
-        if (savedRefreshToken == null || !MessageDigest.isEqual(
-                savedRefreshToken.getBytes(StandardCharsets.UTF_8), // 인코딩 형식 통일
-                incomingRefreshToken.getBytes(StandardCharsets.UTF_8)
-        )) {
-            log.warn("[REISSUE] 유효하지 않은 Refresh Token - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        // refresh token 교체
-        String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
-        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
-        jwtTokenService.saveRefreshToken(userId, newRefreshToken);
-
-        Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
-        log.info("[REISSUE] Refresh Token 재발급 완료 - userId={}", userId);
-
-        return ApiResponse.onSuccess(
-                new ReissueTokenResponseDTO(newAccessToken, newRefreshToken, expiresIn),
-                SuccessStatus.AUTH_REISSUE_SUCCESS.getCode(),
-                SuccessStatus.AUTH_REISSUE_SUCCESS.getMessage()
-        );
-    }
-
-    /**
-     * 로그아웃 처리를 합니다. (저장된 refresh token 삭제)
-     */
-    @Operation(
-            summary = "로그아웃",
-            description = "현재 로그인된 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다."
-    )
-    @PostMapping("/logout")
-    public ApiResponse<Void> logout() {
-
-        Long userId = userContext.getCurrentUserId();
-        boolean result = jwtTokenService.removeRefreshToken(userId);
-
-        if (result) {
-            log.info("[LOGOUT] RefreshToken 삭제 완료 - userId={}", userId);
-        } else {
-            log.info("[LOGOUT] 삭제할 RefreshToken이 없음 - userId={}", userId);
-        }
-
-        return ApiResponse.onSuccess(
-                null,
-                SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
-                SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
-        );
-    }
-}
+//package com.umc.puppymode2.domain.user.auth.controller;
+//
+//import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenRequestDTO;
+//import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenResponseDTO;
+//import com.umc.puppymode2.global.apiPayload.ApiResponse;
+//import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+//import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+//import com.umc.puppymode2.global.auth.context.UserContext;
+//import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
+//import com.umc.puppymode2.global.auth.token.JwtTokenService;
+//import com.umc.puppymode2.global.exception.GeneralException;
+//import io.swagger.v3.oas.annotations.Operation;
+//import io.swagger.v3.oas.annotations.tags.Tag;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.web.bind.annotation.PostMapping;
+//import org.springframework.web.bind.annotation.RequestBody;
+//import org.springframework.web.bind.annotation.RequestMapping;
+//import org.springframework.web.bind.annotation.RestController;
+//
+//import java.nio.charset.StandardCharsets;
+//import java.security.MessageDigest;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@RestController
+//@RequestMapping("/auth")
+//@Tag(name = "Auth", description = "인증 관련 API")
+//public class AuthController {
+//
+//    private final JwtTokenProvider jwtTokenProvider;
+//    private final JwtTokenService jwtTokenService;
+//    private final UserContext userContext;
+//
+//    /**
+//     * refresh token 기반 토큰 재발급
+//     * <p>
+//     * - refresh 토큰을 보내면 저장된 것과 일치하는지 확인합니다.
+//     * - 일치할 경우 access + refresh token을 재발급합니다.
+//     * - 기존 refresh token은 무효화하고, 새 refresh token으로 덮어씁니다.
+//     *
+//     * @param dto ReissueTokenRequestDTO
+//     * @return new access + refresh token
+//     */
+//    @Operation(
+//            summary = "토큰 재발급",
+//            description = "Refresh Token을 기반으로 Access/Refresh Token을 재발급합니다."
+//    )
+//    @PostMapping("/reissue")
+//    public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
+//
+//        String incomingRefreshToken = dto.refreshToken();
+//
+//        Long userId = userContext.getCurrentUserId();
+//        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
+//
+//        // 상수 시간 비교
+//        if (savedRefreshToken == null || !MessageDigest.isEqual(
+//                savedRefreshToken.getBytes(StandardCharsets.UTF_8), // 인코딩 형식 통일
+//                incomingRefreshToken.getBytes(StandardCharsets.UTF_8)
+//        )) {
+//            log.warn("[REISSUE] 유효하지 않은 Refresh Token - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        // refresh token 교체
+//        String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
+//        String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
+//        jwtTokenService.saveRefreshToken(userId, newRefreshToken);
+//
+//        Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
+//        log.info("[REISSUE] Refresh Token 재발급 완료 - userId={}", userId);
+//
+//        return ApiResponse.onSuccess(
+//                new ReissueTokenResponseDTO(newAccessToken, newRefreshToken, expiresIn),
+//                SuccessStatus.AUTH_REISSUE_SUCCESS.getCode(),
+//                SuccessStatus.AUTH_REISSUE_SUCCESS.getMessage()
+//        );
+//    }
+//
+//    /**
+//     * 로그아웃 처리를 합니다. (저장된 refresh token 삭제)
+//     */
+//    @Operation(
+//            summary = "로그아웃",
+//            description = "현재 로그인된 사용자의 Refresh Token을 삭제하여 로그아웃 처리합니다."
+//    )
+//    @PostMapping("/logout")
+//    public ApiResponse<Void> logout() {
+//
+//        Long userId = userContext.getCurrentUserId();
+//        boolean result = jwtTokenService.removeRefreshToken(userId);
+//
+//        if (result) {
+//            log.info("[LOGOUT] RefreshToken 삭제 완료 - userId={}", userId);
+//        } else {
+//            log.info("[LOGOUT] 삭제할 RefreshToken이 없음 - userId={}", userId);
+//        }
+//
+//        return ApiResponse.onSuccess(
+//                null,
+//                SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
+//                SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
+//        );
+//    }
+//}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -9,7 +9,7 @@ import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
 import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
-import com.umc.puppymode2.global.auth.token.JwtTokenService;
+//import com.umc.puppymode2.global.auth.token.JwtTokenService;
 import com.umc.puppymode2.global.security.UserAuthentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,7 +30,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
     private final UserRepository userRepository;
     private final JwtTokenProvider jwtTokenProvider;
-    private final JwtTokenService jwtTokenService;
+//    private final JwtTokenService jwtTokenService;
     private final SocialAuthRepository socialAuthRepository;
 
     @Transactional
@@ -138,11 +138,11 @@ public class UserAuthServiceImpl implements UserAuthService {
         Long userId = user.getUserId();
 
         String accessToken = jwtTokenProvider.generateAccessToken(userId);
-        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
+//        String refreshToken = jwtTokenProvider.generateRefreshToken(userId);
         Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
 
         // Redis에 refresh token 저장
-        jwtTokenService.saveRefreshToken(userId, refreshToken);
+//        jwtTokenService.saveRefreshToken(userId, refreshToken);
 
         log.info("[LOGIN] 토큰 발급 완료 - userId={}", userId);
 
@@ -154,7 +154,7 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         return LoginResponseDTO.builder()
                 .accessToken(accessToken)
-                .refreshToken(refreshToken)
+                .refreshToken(null) //todo: refreshToken으로 변경
                 .expiresIn(expiresIn)
                 .userInfo(loginUserInfo)
                 .build();

--- a/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenService.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenService.java
@@ -1,97 +1,97 @@
-package com.umc.puppymode2.global.auth.token;
-
-import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
-import com.umc.puppymode2.global.exception.GeneralException;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-
-@Slf4j
-@RequiredArgsConstructor
-@Service
-public class JwtTokenService {
-
-    private static final String PREFIX = "RT";
-    private final RedisTemplate<String, String> redisTemplate;
-
-    private final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(14);
-
-    /**
-     * Refresh Token을 Redis에 저장합니다.
-     * <p>
-     * - key: "RT:{userId}"
-     * - value: refreshToken
-     * - TTL: 14일
-     *
-     * @param userId
-     * @param refreshToken
-     */
-    public void saveRefreshToken(Long userId, String refreshToken) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        if (refreshToken == null || refreshToken.trim().isEmpty()) {
-            log.warn("[REDIS] No refresh token is null - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        String key = buildKey(userId);
-
-        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRY);
-        log.info("[REDIS] Saved refresh token - userId={}", userId);
-    }
-
-    /**
-     * Redis에서 유저의 refresh token을 조회합니다.
-     *
-     * @param userId
-     * @return
-     */
-    public String getRefreshToken(Long userId) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        String key = buildKey(userId);
-        String token = redisTemplate.opsForValue().get(key);
-
-        if (token == null) {
-            log.warn("[REDIS] No refresh token is null - userId={}", userId);
-            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
-        }
-
-        return token;
-    }
-
-    /**
-     * Redis에서 해당 유저의 refresh token을 제거합니다.
-     * <p>
-     * - 로그아웃 또는 강제 만료 시 호출됩니다.
-     *
-     * @param userId
-     */
-    public boolean removeRefreshToken(Long userId) {
-
-        if (userId == null) {
-            throw new GeneralException(ErrorStatus.USER_ID_NULL);
-        }
-
-        String key = buildKey(userId);
-        Boolean result = redisTemplate.delete(key);
-
-        boolean isDeleted = Boolean.TRUE.equals(result);
-        log.info("[REDIS] Removed refresh token - result : {} - userId={}", isDeleted, userId);
-
-        return isDeleted;
-    }
-
-    private String buildKey(Long userId) {
-        return PREFIX + userId;
-    }
-}
+//package com.umc.puppymode2.global.auth.token;
+//
+//import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+//import com.umc.puppymode2.global.exception.GeneralException;
+//import lombok.RequiredArgsConstructor;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.Duration;
+//
+//@Slf4j
+//@RequiredArgsConstructor
+//@Service
+//public class JwtTokenService {
+//
+//    private static final String PREFIX = "RT";
+//    private final RedisTemplate<String, String> redisTemplate;
+//
+//    private final Duration REFRESH_TOKEN_EXPIRY = Duration.ofDays(14);
+//
+//    /**
+//     * Refresh Token을 Redis에 저장합니다.
+//     * <p>
+//     * - key: "RT:{userId}"
+//     * - value: refreshToken
+//     * - TTL: 14일
+//     *
+//     * @param userId
+//     * @param refreshToken
+//     */
+//    public void saveRefreshToken(Long userId, String refreshToken) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        if (refreshToken == null || refreshToken.trim().isEmpty()) {
+//            log.warn("[REDIS] No refresh token is null - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        String key = buildKey(userId);
+//
+//        redisTemplate.opsForValue().set(key, refreshToken, REFRESH_TOKEN_EXPIRY);
+//        log.info("[REDIS] Saved refresh token - userId={}", userId);
+//    }
+//
+//    /**
+//     * Redis에서 유저의 refresh token을 조회합니다.
+//     *
+//     * @param userId
+//     * @return
+//     */
+//    public String getRefreshToken(Long userId) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        String key = buildKey(userId);
+//        String token = redisTemplate.opsForValue().get(key);
+//
+//        if (token == null) {
+//            log.warn("[REDIS] No refresh token is null - userId={}", userId);
+//            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+//        }
+//
+//        return token;
+//    }
+//
+//    /**
+//     * Redis에서 해당 유저의 refresh token을 제거합니다.
+//     * <p>
+//     * - 로그아웃 또는 강제 만료 시 호출됩니다.
+//     *
+//     * @param userId
+//     */
+//    public boolean removeRefreshToken(Long userId) {
+//
+//        if (userId == null) {
+//            throw new GeneralException(ErrorStatus.USER_ID_NULL);
+//        }
+//
+//        String key = buildKey(userId);
+//        Boolean result = redisTemplate.delete(key);
+//
+//        boolean isDeleted = Boolean.TRUE.equals(result);
+//        log.info("[REDIS] Removed refresh token - result : {} - userId={}", isDeleted, userId);
+//
+//        return isDeleted;
+//    }
+//
+//    private String buildKey(Long userId) {
+//        return PREFIX + userId;
+//    }
+//}

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -1,113 +1,113 @@
-package com.umc.puppymode2.global.config;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
-import org.springframework.data.redis.core.RedisTemplate;
-import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
-import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
-
-@Slf4j
-@Configuration
-@EnableCaching
-public class RedisConfig {
-
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
-
-    @Value("${spring.data.redis.timeout}")
-    private Duration timeout;
-
-    @Value("${spring.data.redis.ssl:false}")
-    private boolean sslEnabled;
-
-    /**
-     * LettuceClientFactory 생성
-     * - ssl 사용
-     * - password 설정
-     * - connection timeout 지정
-     *
-     * @return
-     */
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(host);
-        config.setPort(port);
-
-        if (password != null && !password.isBlank()) {
-            config.setPassword(password);
-        }
-
-        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
-                LettuceClientConfiguration.builder()
-                        .commandTimeout(timeout)
-                        .shutdownTimeout(Duration.ofMillis(100));
-
-        // 환경에 따라 TLS 적용
-        if (sslEnabled) {
-            builder.useSsl();
-        }
-
-        LettuceClientConfiguration clientConfiguration = builder.build();
-
-        return new LettuceConnectionFactory(config, clientConfiguration);
-    }
-
-    /**
-     * RedisTemplate 설정
-     * - Key: String
-     * - Value: Json 직렬화
-     * - HashKey: String
-     * - HashValue: Json 직렬화
-     *
-     * @param connectionFactory
-     * @param objectMapper
-     * @return
-     */
-    @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory,
-                                                       ObjectMapper objectMapper) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-
-        // Key 직렬화
-        template.setKeySerializer(new StringRedisSerializer());
-        template.setHashKeySerializer(new StringRedisSerializer());
-
-        // Value 직렬화
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
-
-        template.afterPropertiesSet();
-        return template;
-    }
-
-    @Bean
-    public CommandLineRunner safeRedisCheck(LettuceConnectionFactory cf) {
-        return args -> {
-            try {
-                log.info("[REDIS] {}", cf.getConnection().ping());
-            } catch (Exception e) {
-                log.warn("[REDIS] 초기 연결 실패 {}", e.getMessage());
-                throw new IllegalStateException("Redis 연결 실패 - 애플리케이션 중단", e);
-            }
-        };
-    }
-}
+//package com.umc.puppymode2.global.config;
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Value;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.cache.annotation.EnableCaching;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.data.redis.connection.RedisConnectionFactory;
+//import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+//import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+//import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+//import org.springframework.data.redis.core.RedisTemplate;
+//import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+//import org.springframework.data.redis.serializer.StringRedisSerializer;
+//
+//import java.time.Duration;
+//
+//@Slf4j
+//@Configuration
+//@EnableCaching
+//public class RedisConfig {
+//
+//    @Value("${spring.data.redis.host}")
+//    private String host;
+//
+//    @Value("${spring.data.redis.port}")
+//    private int port;
+//
+//    @Value("${spring.data.redis.password}")
+//    private String password;
+//
+//    @Value("${spring.data.redis.timeout}")
+//    private Duration timeout;
+//
+//    @Value("${spring.data.redis.ssl:false}")
+//    private boolean sslEnabled;
+//
+//    /**
+//     * LettuceClientFactory 생성
+//     * - ssl 사용
+//     * - password 설정
+//     * - connection timeout 지정
+//     *
+//     * @return
+//     */
+//    @Bean
+//    public RedisConnectionFactory redisConnectionFactory() {
+//        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
+//        config.setHostName(host);
+//        config.setPort(port);
+//
+//        if (password != null && !password.isBlank()) {
+//            config.setPassword(password);
+//        }
+//
+//        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
+//                LettuceClientConfiguration.builder()
+//                        .commandTimeout(timeout)
+//                        .shutdownTimeout(Duration.ofMillis(100));
+//
+//        // 환경에 따라 TLS 적용
+//        if (sslEnabled) {
+//            builder.useSsl();
+//        }
+//
+//        LettuceClientConfiguration clientConfiguration = builder.build();
+//
+//        return new LettuceConnectionFactory(config, clientConfiguration);
+//    }
+//
+//    /**
+//     * RedisTemplate 설정
+//     * - Key: String
+//     * - Value: Json 직렬화
+//     * - HashKey: String
+//     * - HashValue: Json 직렬화
+//     *
+//     * @param connectionFactory
+//     * @param objectMapper
+//     * @return
+//     */
+//    @Bean
+//    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory,
+//                                                       ObjectMapper objectMapper) {
+//        RedisTemplate<String, Object> template = new RedisTemplate<>();
+//        template.setConnectionFactory(connectionFactory);
+//
+//        // Key 직렬화
+//        template.setKeySerializer(new StringRedisSerializer());
+//        template.setHashKeySerializer(new StringRedisSerializer());
+//
+//        // Value 직렬화
+//        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+//        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+//
+//        template.afterPropertiesSet();
+//        return template;
+//    }
+//
+//    @Bean
+//    public CommandLineRunner safeRedisCheck(LettuceConnectionFactory cf) {
+//        return args -> {
+//            try {
+//                log.info("[REDIS] {}", cf.getConnection().ping());
+//            } catch (Exception e) {
+//                log.warn("[REDIS] 초기 연결 실패 {}", e.getMessage());
+//                throw new IllegalStateException("Redis 연결 실패 - 애플리케이션 중단", e);
+//            }
+//        };
+//    }
+//}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,13 +17,13 @@ spring:
         hbm2ddl:
           auto: update
         default_batch_fetch_size: 1000
-  data:
-    redis:
-      host: ${REDIS_HOST}
-      port: 6379
-      password: ${REDIS_AUTH_TOKEN}
-      timeout: ${REDIS_TIMEOUT:2s}
-      ssl-enabled: ${REDIS_SSL_ENABLED:false}
+#  data:
+#    redis:
+#      host: ${REDIS_HOST}
+#      port: 6379
+#      password: ${REDIS_AUTH_TOKEN}
+#      timeout: ${REDIS_TIMEOUT:2s}
+#      ssl-enabled: ${REDIS_SSL_ENABLED:false}
 
 auth:
   jwt:


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
캐시 연결 실패로 인한 비활성화

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기능 변경**
  * 사용자 인증 토큰 재발급 엔드포인트가 비활성화되었습니다. 기존 로그인 세션의 토큰 갱신이 더 이상 지원되지 않습니다
  * 애플리케이션 로그아웃 기능이 비활성화되었습니다
  * 리프레시 토큰 메커니즘이 제거되어 토큰 자동 갱신 기능이 미지원됩니다

* **Chores**
  * 기본 인프라 및 시스템 의존성 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->