### PR TITLE
[BUG] redisConfig value 수정 #59

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -34,7 +34,7 @@ public class RedisConfig {
     @Value("${spring.data.redis.timeout}")
     private Duration timeout;
 
-    @Value("${spring.data.redis.ssl:false}")
+    @Value("${spring.data.redis.ssl-enabled:false}")
     private boolean sslEnabled;
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,9 +23,7 @@ spring:
       port: 6379
       password: ${REDIS_AUTH_TOKEN}
       timeout: ${REDIS_TIMEOUT:2s}
-      client:
-        type: lettuce
-        ssl: ${REDIS_SSL_ENABLED:false}
+      ssl-enabled: ${REDIS_SSL_ENABLED:false}
 
 auth:
   jwt:


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
redis value값을 제대로 연결되도록 수정한 후 재배포 합니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  
- application.yml 의 값과 redisConfig의 값 일치하도록 수정
- aws에서 timeout 10s 로 증가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
