### PR TITLE
Refactor/#74 withdraw userdata delete

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -20,4 +20,5 @@ public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long
                                  @Param("start") LocalDate start,
                                  @Param("end") LocalDate end);
     long countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
+    long countByUserUserIdAndIsDrinkTrue(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -2,6 +2,9 @@ package com.umc.puppymode2.domain.goal.repository;
 
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -12,4 +15,8 @@ public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory
     Optional<UserGoalHistory> findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(
             Long userId, LocalDateTime asOfDate
     );
+
+    @Modifying
+    @Query("DELETE FROM UserGoalHistory ugh WHERE ugh.userId = :userId")
+    void deleteAllByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/entity/Puppy.java
@@ -19,7 +19,7 @@ public class Puppy extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 

--- a/src/main/java/com/umc/puppymode2/domain/user/batch/WithdrawalDataCleanupBatch.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/batch/WithdrawalDataCleanupBatch.java
@@ -1,0 +1,29 @@
+package com.umc.puppymode2.domain.user.batch;
+
+import com.umc.puppymode2.domain.user.repository.WithDrawnUserArchiveRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WithdrawalDataCleanupBatch {
+
+    private final WithDrawnUserArchiveRepository withdrawnUserArchiveRepository;
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @Transactional
+    public void cleanupExpiredWithdrawalData() {
+        try {
+            withdrawnUserArchiveRepository.deleteExpiredArchive(LocalDateTime.now());
+            log.info("[Batch] 만료된 탈퇴 보관 데이터 삭제 완료");
+        } catch (Exception e) {
+            log.error("[Batch] 탈퇴 데이터 삭제 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -1,11 +1,15 @@
 package com.umc.puppymode2.domain.user.entity;
 
+import com.umc.puppymode2.domain.advice.entity.Advice;
 import com.umc.puppymode2.domain.common.BaseEntity;
+import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
 import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,8 +39,19 @@ public class User extends BaseEntity {
     @Column(name = "is_custom_name", nullable = false)
     private boolean isCustomName = false;
 
+    private LocalDateTime withdrawnAt;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<SocialAuth> socialAuths = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DrinkHistory> drinkHistories = new ArrayList<>();
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Advice> advices = new ArrayList<>();
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Puppy puppy;
 
     public void addSocialAuth(SocialAuth socialAuth) {
         socialAuths.add(socialAuth);
@@ -83,5 +98,21 @@ public class User extends BaseEntity {
     public void setUsername(String username) {
         this.username = username;
         this.isCustomName = true;
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.STOP;
+        this.withdrawnAt = LocalDateTime.now();
+
+        // 개인 정보 마스킹
+        this.email = "withdrawn_" + userId + "@deleted.com";
+        this.username = "탈퇴한 사용자";
+        this.receiveNotifications = false;
+
+        // CASCADE로 자동 삭제
+        this.socialAuths.clear();
+        this.drinkHistories.clear();
+        this.advices.clear();
+        this.puppy = null;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/WithdrawnUserArchive.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/WithdrawnUserArchive.java
@@ -33,7 +33,7 @@ public class WithdrawnUserArchive extends BaseEntity {
     public static WithdrawnUserArchive fromUser(User user, Integer totalDrinkDays) {
         return WithdrawnUserArchive.builder()
                 .originalUserId(user.getUserId())
-                .maskedEmail(user.getEmail())
+                .maskedEmail("withdrawn_" + user.getUserId() + "@deleted.com")
                 .provider(user.getProvider())
                 .withdrawnAt(LocalDateTime.now())
                 .signupAt(user.getCreatedAt())

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/WithdrawnUserArchive.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/WithdrawnUserArchive.java
@@ -1,0 +1,44 @@
+package com.umc.puppymode2.domain.user.entity;
+
+import com.umc.puppymode2.domain.common.BaseEntity;
+import com.umc.puppymode2.domain.user.auth.enums.Provider;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "withdrawn_user_archive")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
+public class WithdrawnUserArchive extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long archiveId;
+
+    private Long originalUserId;
+    private String maskedEmail;
+
+    @Enumerated(EnumType.STRING)
+    private Provider provider;
+
+    private LocalDateTime withdrawnAt;
+    private LocalDateTime signupAt;
+    private Integer totalDrinkDays;
+    private LocalDateTime dataRetentionUntil;
+
+    public static WithdrawnUserArchive fromUser(User user, Integer totalDrinkDays) {
+        return WithdrawnUserArchive.builder()
+                .originalUserId(user.getUserId())
+                .maskedEmail(user.getEmail())
+                .provider(user.getProvider())
+                .withdrawnAt(LocalDateTime.now())
+                .signupAt(user.getCreatedAt())
+                .totalDrinkDays(totalDrinkDays)
+                .dataRetentionUntil(LocalDateTime.now().plusMonths(3))
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/WithDrawnUserArchiveRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/WithDrawnUserArchiveRepository.java
@@ -1,0 +1,18 @@
+package com.umc.puppymode2.domain.user.repository;
+
+import com.umc.puppymode2.domain.user.entity.WithdrawnUserArchive;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+public interface WithDrawnUserArchiveRepository extends JpaRepository<WithdrawnUserArchive, Long> {
+
+    @Modifying
+    @Query("DELETE FROM WithdrawnUserArchive w WHERE w.dataRetentionUntil < :now")
+    void deleteExpiredArchive(@Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
@@ -1,15 +1,21 @@
 package com.umc.puppymode2.domain.user.service;
 
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.user.entity.SocialAuth;
 import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.entity.WithdrawnUserArchive;
 import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
 import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
+import com.umc.puppymode2.domain.user.repository.WithDrawnUserArchiveRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService {
@@ -17,32 +23,89 @@ public class UserCommandServiceImpl implements UserCommandService {
     private final UserRepository userRepository;
     private final SocialAuthRepository socialAuthRepository;
     private final KakaoAuthService kakaoAuthService;
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
+    private final WithDrawnUserArchiveRepository withdrawnUserArchiveRepository;
+    private final DrinkHistoryRepository drinkHistoryRepository;
 
     @Override
     @Transactional
     public void withdrawUser(Long userId) {
+        // 1. 유저 조회 및 상태 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+
         if (user.getStatus() == UserStatus.STOP) {
             throw new IllegalArgumentException("이미 탈퇴한 유저입니다.");
         }
+
+        // 2. 카카오 연동 정보 조회
         SocialAuth socialAuth = socialAuthRepository.findByUserUserIdAndProvider(userId, Provider.KAKAO)
                 .orElseThrow(() -> new IllegalArgumentException("카카오 연동 정보가 없습니다."));
-        String accessToken = socialAuth.getAccessToken();
-        // 1. access token 없거나 만료 시 refresh로 재발급
-        if (accessToken == null) {
-            accessToken = kakaoAuthService.refreshAccessToken(userId);
-            socialAuth.setAccessToken(accessToken);
-            socialAuthRepository.save(socialAuth);
+
+        // 3. 법적 보관 데이터 생성
+        Integer totalDrinkDays = getTotalDrinkDays(userId);
+        WithdrawnUserArchive archive = WithdrawnUserArchive.fromUser(user, totalDrinkDays);
+        withdrawnUserArchiveRepository.save(archive);
+        log.info("[Withdraw] 법적 보관 데이터 생성 완료 - userId: {}", userId);
+
+        // 4. 카카오 연결 끊기
+        boolean unlinked = disconnectKakao(userId, socialAuth);
+
+        // 5. UserGoalHistory 삭제
+        try {
+            userGoalHistoryRepository.deleteAllByUserId(userId);
+            log.info("[Withdraw] 목표 히스토리 삭제 완료 - userId: {}", userId);
+        } catch (Exception e) {
+            log.error("[Withdraw] 목표 히스토리 삭제 실패 - userId: {}", userId, e);
+            throw new RuntimeException("탈퇴 처리 중 오류가 발생했습니다.", e);
         }
-        boolean unlinked = kakaoAuthService.disconnectKakao(accessToken);
-        if (!unlinked) {
-            // 운영 로그, 인시던트, Fallback(AdminKey) 여부 정책 검토 후
-            // 서비스 내 유저는 탈퇴처리(soft delete)
-        }
-        user.setStatus(UserStatus.STOP);
-        user.getSocialAuths().clear();
+
+        // 6. User 탈퇴 처리 (CASCADE로 연관 데이터를 자동 삭제함)
+        user.withdraw();
         userRepository.save(user);
+
+        log.info("[Withdraw] 탈퇴 완료 - userId: {}, kakaoUnlinked: {}", userId, unlinked);
     }
 
+    /**
+     * 카카오 연결 끊기 (Access Token 사용)
+     */
+    private boolean disconnectKakao(Long userId, SocialAuth socialAuth) {
+        String accessToken = socialAuth.getAccessToken();
+
+        // access token 없거나 만료 시 refresh로 재발급
+        if (accessToken == null) {
+            try {
+                accessToken = kakaoAuthService.refreshAccessToken(userId);
+                socialAuth.setAccessToken(accessToken);
+                socialAuthRepository.save(socialAuth);
+            } catch (Exception e) {
+                log.warn("[Withdraw] Access Token 재발급 실패 - userId: {}", userId, e);
+            }
+        }
+
+        // User Access Token으로 연결 해제 시도
+        if (accessToken != null) {
+            boolean unlinked = kakaoAuthService.disconnectKakao(accessToken);
+            if (unlinked) {
+                log.info("[Withdraw] 카카오 연결 해제 성공 - userId: {}", userId);
+            }
+        }
+
+        // 카카오 연결 해제 실패 - 서비스 내 탈퇴는 진행함
+        log.warn("[Withdraw] 카카오 연결 해제 실패 - userId: {} (서비스 내 탈퇴는 진행)", userId);
+        return false;
+    }
+
+    /**
+     * 총 음주일수 계산
+     */
+    private Integer getTotalDrinkDays(Long userId) {
+        try {
+            return (int)drinkHistoryRepository.countByUserUserIdAndIsDrinkTrue(userId);
+        } catch (Exception e) {
+            log.warn("[Withdraw] 음주일수 계산 실패 - userId: {}", userId, e);
+            return 0;
+        }
+    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserCommandServiceImpl.java
@@ -89,6 +89,7 @@ public class UserCommandServiceImpl implements UserCommandService {
             boolean unlinked = kakaoAuthService.disconnectKakao(accessToken);
             if (unlinked) {
                 log.info("[Withdraw] 카카오 연결 해제 성공 - userId: {}", userId);
+                return true;
             }
         }
 


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
유저 탈퇴 기능 구현 및 관련 엔티티 데이터 삭제 처리

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #74 

## 🔍 작업 내용  
- User 탈퇴 처리 메서드 구현 (soft delete + 개인정보 마스킹)
- 탈퇴 시 관련된 SocialAuth, DrinkHistory, Advice, Puppy 엔티티 연관 데이터 CASCADE로 자동 삭제 반영
- 법적 보관을 위한 WithdrawnUserArchive 엔티티 추가 및 탈퇴 시 데이터 저장 기능 구현
- UserGoalHistory 데이터 탈퇴 시점에 직접 삭제 처리 구현

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
@Yunji-Yun Puppy 테이블 관계 ManyToOne에서 OneToOne으로 변경했습니다. (유저당 강아지는 한 마리만 할당받을 수 있도록)

@eldeoddt 탈퇴 시점에 SocialAuth 데이터가 삭제됩니다.
@twosky0202 탈퇴 시점에 음주 기록 히스토리 데이터(DrinkHistory)가 삭제됩니다.
@hjyoon99 탈퇴 시점에 한마디 기록 데이터(Advice)가 삭제됩니다.
@SeoJin-L-ee 탈퇴 시점에 강아지 데이터(Puppy)가 삭제됩니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 탈퇴 시 사용자 데이터 아카이브 생성 및 외부 연동(카카오) 연결 해제 절차 추가
  * 탈퇴 계정의 만료된 아카이브를 매일 오전 3시에 자동 정리

* **개선 사항**
  * 탈퇴 처리 시 개인정보 마스킹 및 관련 데이터 일괄 정리 안정성 향상
  * 사용자·반려동물 관계 모델 조정 및 활동(음주) 집계 기능 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->