### PR TITLE
[FEAT] PuppyType enum 필드 수정 #80

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestResDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/dto/OnboardingTestResDTO.java
@@ -3,8 +3,9 @@ package com.umc.puppymode2.domain.onboarding.dto;
 public record OnboardingTestResDTO(
 
         String type, // 예: "분위기 리더형"
-        String puppyBreed, // 예: "비숑 프리제"
-        String description, // 타입에 대한 설명
+        String puppyBreedKo, // 예: "비숑 프리제"
+        String puppyBreedEn, // 예: "Bichon Frisé"
+        String description, // 타입 설명, 예: "술자리를 이끄는 사람들"
         String imageUrl // 강아지 이미지 url
 ) {
 }

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -78,7 +78,7 @@ public class OnboardingTestService {
         Puppy puppy = Puppy.builder()
                 .user(user)
                 .puppyLevel(level1)
-                .puppyName(level1.getPuppyType().getBreed())
+                .puppyName(level1.getPuppyType().getBreedKo())
                 .puppyExp(0)
                 .build();
         puppyRepository.save(puppy);
@@ -86,7 +86,8 @@ public class OnboardingTestService {
         // 온보딩 화면에 검사 결과로 표시될 데이터 DTO 생성 및 반환
         return new OnboardingTestResDTO(
                 type.getType(),
-                type.getBreed(),
+                type.getBreedKo(),
+                type.getBreedEn(),
                 type.getDescription(),
                 type.getImageUrl()
         );

--- a/src/main/java/com/umc/puppymode2/domain/puppy/entity/PuppyType.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/entity/PuppyType.java
@@ -5,19 +5,21 @@ import lombok.Getter;
 @Getter
 public enum PuppyType {
 
-    BICHON("분위기 리더형", "비숑", "술자리를 이끄는 활발하고 감성적인 리더!", "https://example.image.url.com"),
-    SHIBA("은밀한 취객형", "시바견", "혼술을 사랑하는 섬세한 감성가!", "https://example.image.url.com"),
-    CORGI("컨트롤러형", "웰시코기", "술을 도구처럼 다루는 전략가!", "https://example.image.url.com"),
-    POODLE("관찰자형", "푸들", "술자리에서도 분석과 기록을 놓치지 않는 관찰자!", "https://example.image.url.com");
+    BICHON("분위기 리더형", "비숑 프리제", "Bichon Frisé", "술자리를 이끄는 사람들", "https://puppy-mode-s3-bucket.s3.ap-northeast-2.amazonaws.com/bichon_default_level1.svg"),
+    SHIBA("은밀한 취객형", "시바견", "Shiba Inu", "혼술 장인", "https://puppy-mode-s3-bucket.s3.ap-northeast-2.amazonaws.com/shiba_default_level1.svg"),
+    CORGI("컨트롤러형", "웰시코기", "Welsh Corgi", "술은 도구, 취함은 선택", "https://puppy-mode-s3-bucket.s3.ap-northeast-2.amazonaws.com/corgi_default_level1.svg"),
+    POODLE("관찰자형", "푸들", "Poodle", "분석하고 기록하는 술자리 학자들", "https://puppy-mode-s3-bucket.s3.ap-northeast-2.amazonaws.com/poodle_default_level1.svg");
 
     private final String type; // 성향 이름
-    private final String breed; // 견종
-    private final String description; // 소개 문구
+    private final String breedKo; // 견종 (한글명)
+    private final String breedEn; // 견종 (영문명)
+    private final String description; // 성향 설명
     private final String imageUrl; // 강아지 대표 이미지
 
-    PuppyType(String type, String breed, String description, String imageUrl) {
+    PuppyType(String type, String breedKo, String breedEn, String description, String imageUrl) {
         this.type = type;
-        this.breed = breed;
+        this.breedKo = breedKo;
+        this.breedEn = breedEn;
         this.description = description;
         this.imageUrl = imageUrl;
     }


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 온보딩 테스트 결과 화면 세부정보 변경에 따른 온보딩 테스트 API 응답 DTO 수정
    - 강아지 종 영문명 추가
    - 실제 접근 가능한 imageUrl로 변경

---

아래와 같은 응답 DTO를 반환하도록 수정했습니다.

{
    "type": "분위기 리더형",
    "puppyBreedKo": "비숑 프리제",
    "puppyBreedEn": "Bichon Frisé",
    "description": "술자리를 이끄는 사람들",
    "imageUrl": "https://puppy-mode-s3-bucket.s3~~"
  }

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #80 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **기능 개선**
  * 견종 정보가 한국어와 영어 모두로 표시됩니다. 온보딩 프로세스에서 사용자가 견종 이름을 두 언어로 확인할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->