### PR TITLE
[FEAT] 메인 화면 조회 시 강아지 이름 추가 #82

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
@@ -11,6 +11,7 @@ public class MainResponseDto {
     private String puppyLevelName;   // 레벨 이름
     private int puppyLevelPercent;   // 경험치 진행률(%)
     private String puppyImageUrl;    // 강아지 레벨 이미지 URL
+    private String currentPuppyName;
 
     @JsonProperty("isPuppyName")
     private boolean puppyName;     // 강아지 이름 지어주기 여부

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -59,6 +59,7 @@ public class MainServiceImpl implements MainService {
                 .puppyLevelName(level.getLevelName())
                 .puppyLevelPercent(percent)
                 .puppyImageUrl(level.getLevelImageUrl())
+                .currentPuppyName(puppy.getPuppyName())
                 .puppyName(isPuppyName)
                 .myName(isMyName)
                 .goal(isGoal)


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
메인 화면 조회 시 강아지 이름도 보이도록 추가했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #82 

## 🔍 작업 내용  
- 메인 화면 조회 시 강아지 이름 'currentPuppyName) 추가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새 기능

* 메인 페이지에 사용자가 현재 관리 중인 반려동물의 이름이 명확하게 표시되는 편리한 기능이 새로 추가되었습니다. 사용자는 앱을 실행할 때마다 메인 화면에서 자신의 반려동물 이름을 즉시 확인할 수 있으며, 반려동물 관련 정보와 주요 기능에 더욱 신속하고 효율적으로 접근할 수 있게 되었습니다. 이로 인해 앱의 전반적인 편의성이 향상되었고 사용자 만족도와 사용 경험이 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->