### PR TITLE
[FIX] redis 연결 url 방식으로 변경 #59

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -2,73 +2,19 @@ package com.umc.puppymode2.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
-import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
-import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
-
-import java.time.Duration;
 
 @Slf4j
 @Configuration
 @EnableCaching
 public class RedisConfig {
-
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
-
-    @Value("${spring.data.redis.timeout}")
-    private Duration timeout;
-
-    @Value("${spring.data.redis.ssl-enabled:false}")
-    private boolean sslEnabled;
-
-    /**
-     * LettuceClientFactory 생성
-     * - ssl 사용
-     * - password 설정
-     * - connection timeout 지정
-     *
-     * @return
-     */
-    @Bean
-    public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
-        config.setHostName(host);
-        config.setPort(port);
-
-        if (password != null && !password.isBlank()) {
-            config.setPassword(password);
-        }
-
-        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
-                LettuceClientConfiguration.builder()
-                        .commandTimeout(timeout)
-                        .shutdownTimeout(Duration.ofMillis(100));
-
-        // 환경에 따라 TLS 적용
-        if (sslEnabled) {
-            builder.useSsl();
-        }
-
-        LettuceClientConfiguration clientConfiguration = builder.build();
-
-        return new LettuceConnectionFactory(config, clientConfiguration);
-    }
 
     /**
      * RedisTemplate 설정
@@ -77,7 +23,7 @@ public class RedisConfig {
      * - HashKey: String
      * - HashValue: Json 직렬화
      *
-     * @param connectionFactory
+     * @param connectionFactory Spring Boot가 자동 생성한 ConnectionFactory
      * @param objectMapper
      * @return
      */
@@ -100,12 +46,13 @@ public class RedisConfig {
     }
 
     @Bean
-    public CommandLineRunner safeRedisCheck(LettuceConnectionFactory cf) {
+    public CommandLineRunner safeRedisCheck(RedisConnectionFactory cf) {
         return args -> {
             try {
-                log.info("[REDIS] {}", cf.getConnection().ping());
+                String result = cf.getConnection().ping();
+                log.info("[REDIS] 연결 성공! - PING 응답: {}", result);
             } catch (Exception e) {
-                log.warn("[REDIS] 초기 연결 실패 {}", e.getMessage());
+                log.warn("[REDIS] 초기 연결 실패: {}", e.getMessage());
                 throw new IllegalStateException("Redis 연결 실패 - 애플리케이션 중단", e);
             }
         };

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,11 +19,8 @@ spring:
         default_batch_fetch_size: 1000
   data:
     redis:
-      host: ${REDIS_HOST}
-      port: 6379
-      password: ${REDIS_AUTH_TOKEN}
-      timeout: ${REDIS_TIMEOUT:2s}
-      ssl-enabled: ${REDIS_SSL_ENABLED:false}
+      url: rediss://:${REDIS_AUTH_TOKEN}@${REDIS_HOST}:6379
+      timeout: ${REDIS_TIMEOUT:10s}
 
 auth:
   jwt:


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
redis 에서 
tls 연결 + Transit encryption mode 조건 충족을 위해서 
기존 수동 설정 -> url 연결 방식으로 변경했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  
- application.yml: host/port/password 개별 설정 → rediss:// URL 통합 설정
- RedisConfig.java: 수동 ConnectionFactory 생성 → Spring Boot 자동 구성 활용
- 동일한 Lettuce 클라이언트 사용, 설정 방식만 변경

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 설정을 단순화했습니다. 개별 연결 속성을 통합 URL 형식으로 변경했습니다.
  * Redis 상태 확인 로깅을 개선하여 응답 메시지를 명확하게 표시합니다.
  * Redis 타임아웃을 2초에서 10초로 연장했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->