### PR TITLE
[FEAT] 인증 관련 api 예외 처리 추가 및 swagger 설정 #59

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -9,6 +9,7 @@ import com.umc.puppymode2.global.auth.context.UserContext;
 import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
 import com.umc.puppymode2.global.auth.token.JwtTokenService;
 import com.umc.puppymode2.global.config.RequiresRedis;
+import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import com.umc.puppymode2.global.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -49,6 +50,11 @@ public class AuthController {
     )
     @PostMapping("/reissue")
     @RequiresRedis
+    @ApiErrorCodeExamples({
+            ErrorStatus.AUTH_INVALID_TOKEN,
+            ErrorStatus.REDIS_CONNECTION_FAILURE,
+            ErrorStatus.AUTH_REFRESH_TOKEN_INVALID
+    })
     public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
 
         String incomingRefreshToken = dto.refreshToken();
@@ -89,6 +95,10 @@ public class AuthController {
     )
     @PostMapping("/logout")
     @RequiresRedis
+    @ApiErrorCodeExamples({
+            ErrorStatus.AUTH_INVALID_TOKEN,
+            ErrorStatus.REDIS_CONNECTION_FAILURE
+    })
     public ApiResponse<Void> logout() {
 
         Long userId = userContext.getCurrentUserId();

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
@@ -4,10 +4,12 @@ import com.umc.puppymode2.domain.user.auth.dto.KakaoLoginRequestDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.service.KakaoAuthService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
 import com.umc.puppymode2.domain.user.auth.service.UserAuthService;
+import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import io.swagger.v3.oas.annotations.Operation;
 
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -35,7 +37,12 @@ public class KakaoAuthController {
             description = "카카오 서버로부터 발급받은 `Access Token`과 `Refresh Token`을 사용하여,  \n" +
                     "서버에서 JWT를 발급받는 API입니다.  \n" +
                     "* 이미 가입된 유저면 로그인 처리  \n" +
-                    "* 신규 유저면 회원가입 후 로그인 처리")
+                    "* 신규 유저면 회원가입 후 로그인 처리  \n\n" +
+                    "**주의:** Redis 서버 장애 시 refreshToken 없이 로그인됩니다.")
+    @ApiErrorCodeExamples({
+            ErrorStatus._BAD_REQUEST,
+            ErrorStatus.AUTH_INVALID_TOKEN
+    })
     public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
             @Valid @RequestBody KakaoLoginRequestDTO request
     ) {

--- a/src/main/java/com/umc/puppymode2/global/config/swagger/ApiErrorCodeExampleCustomizer.java
+++ b/src/main/java/com/umc/puppymode2/global/config/swagger/ApiErrorCodeExampleCustomizer.java
@@ -1,0 +1,101 @@
+package com.umc.puppymode2.global.config.swagger;
+
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.*;
+
+/**
+ * @ApiErrorCodeExamples 어노테이션을 읽어서 Swagger에 에러 응답을 자동으로 추가
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ApiErrorCodeExampleCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+
+        ApiErrorCodeExamples annotation = handlerMethod.getMethodAnnotation(ApiErrorCodeExamples.class);
+
+        if (annotation == null) {
+            return operation;
+        }
+
+        List<ErrorStatus> errorStatuses = Arrays.asList(annotation.value());
+
+        if (errorStatuses.isEmpty()) {
+            return operation;
+        }
+
+        ApiResponses responses = operation.getResponses();
+        if (responses == null) {
+            responses = new ApiResponses();
+            operation.setResponses(responses);
+        }
+
+        for (ErrorStatus errorStatus : errorStatuses) {
+            String statusCode = String.valueOf(errorStatus.getReasonHttpStatus().getHttpStatus().value());
+            ExampleHolder holder = createExampleHolder(errorStatus);
+
+            ApiResponse apiResponse = responses.computeIfAbsent(statusCode, code -> new ApiResponse());
+
+            if (apiResponse.getDescription() == null) {
+                apiResponse.setDescription("Error Response");
+            }
+
+            Content content = apiResponse.getContent();
+            if (content == null) {
+                content = new Content();
+                apiResponse.setContent(content);
+            }
+
+            MediaType mediaType = content.get("application/json");
+            if (mediaType == null) {
+                mediaType = new MediaType();
+                // ApiResponse 스키마 참조
+                mediaType.setSchema(new Schema<>().$ref("#/components/schemas/ApiResponse"));
+                content.addMediaType("application/json", mediaType);
+            }
+
+            mediaType.addExamples(holder.getName(), holder.getHolder());
+        }
+
+        return operation;
+    }
+
+    /**
+     * ErrorStatus로부터 ExampleHolder 생성
+     */
+    private ExampleHolder createExampleHolder(ErrorStatus errorStatus) {
+        // ApiResponse.onFailure() 사용
+        com.umc.puppymode2.global.apiPayload.ApiResponse<Object> errorResponse =
+                com.umc.puppymode2.global.apiPayload.ApiResponse.onFailure(
+                        errorStatus.getCode(),
+                        errorStatus.getMessage(),
+                        null
+                );
+
+        Example example = new Example();
+        example.setSummary(errorStatus.name());
+        example.setDescription(errorStatus.getMessage());
+        example.setValue(errorResponse);
+
+        return ExampleHolder.builder()
+                .holder(example)
+                .name(errorStatus.name())
+                .code(errorStatus.getReasonHttpStatus().getHttpStatus().value())
+                .build();
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/config/swagger/ApiErrorCodeExamples.java
+++ b/src/main/java/com/umc/puppymode2/global/config/swagger/ApiErrorCodeExamples.java
@@ -1,0 +1,22 @@
+package com.umc.puppymode2.global.config.swagger;
+
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Swagger에서 API 응답 예외 코드를 문서화하기 위한 어노테이션
+ *
+ * 사용 예시:
+ * @ApiErrorCodeExamples({
+ *   ErrorStatus.USER_NOT_FOUND,
+ *   ErrorStatus.REDIS_CONNECTION_FAILURE
+ * })
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorCodeExamples {
+    ErrorStatus[] value();
+}

--- a/src/main/java/com/umc/puppymode2/global/config/swagger/ExampleHolder.java
+++ b/src/main/java/com/umc/puppymode2/global/config/swagger/ExampleHolder.java
@@ -1,0 +1,16 @@
+package com.umc.puppymode2.global.config.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Swagger 응답 예시를 담는 클래스
+ */
+@Getter
+@Builder
+public class ExampleHolder {
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/com/umc/puppymode2/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/swagger/SwaggerConfig.java
@@ -1,4 +1,4 @@
-package com.umc.puppymode2.global.config;
+package com.umc.puppymode2.global.config.swagger;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OperationCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -38,5 +39,13 @@ public class SwaggerConfig {
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    /**
+     * @ApiErrorCodeExamples 어노테이션을 처리하는 커스터마이저
+     */
+    @Bean
+    public OperationCustomizer operationCustomizer() {
+        return new ApiErrorCodeExampleCustomizer();
     }
 }


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
인증 관련 예외 처리 추가, 예외 응답 swagger 자동 문서화 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  
- redis 관련 예외 추가 (redis 연결실패시)
- swagger 예외 응답 자동 문서화 구현 - @ApiErrorCodeExamples 어노테이션
  - 노션 참고: https://www.notion.so/Swagger-2bfc3b1c55ee8072a9c1ee3fc37f136d

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * API 문서에서 엔드포인트별 가능한 에러 코드 및 응답 예시를 자동으로 표시하는 기능이 추가되었습니다. Swagger 문서가 더욱 상세한 에러 정보를 제공하여 API 통합 시 개발자의 편의성이 향상되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->