### PR TITLE
Feat/#97 apple login

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
@@ -1,5 +1,6 @@
 package com.umc.puppymode2.domain.user.auth.config;
 
+import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -8,6 +9,8 @@ import org.springframework.stereotype.Component;
 /**
  * Apple OAuth 인증을 위한 설정 클래스
  * application.yml의 auth.apple 하위 설정값을 로드합니다.
+ * <p>
+ * 애플리케이션 시작 시 필수 설정값 검증
  */
 @Slf4j
 @Getter
@@ -26,6 +29,55 @@ public class AppleAuthConfig {
     @Value("${auth.apple.private-key}")
     private String privateKey;
 
-    @Value("${auth.apple.redirect-uri:https://puppy-mode.info/auth/apple/callback}")
+    @Value("${auth.apple.redirect-uri}")
     private String redirectUri;
+
+    /**
+     * 애플리케이션 시작 시 필수 설정값을 검증합니다.
+     * 설정 누락 시 에러 메시지와 함께 시작 실패
+     */
+    @PostConstruct
+    public void validate() {
+        log.info("[Apple Config] Apple 인증 설정 검증 시작");
+
+        if (isBlank(teamId)) {
+            throw new IllegalStateException("Apple Team ID가 설정되지 않았습니다. auth.apple.team-id를 확인하세요.");
+        }
+
+        if (isBlank(clientId)) {
+            throw new IllegalStateException("Apple Client ID가 설정되지 않았습니다. auth.apple.client-id를 확인하세요.");
+        }
+
+        if (isBlank(keyId)) {
+            throw new IllegalStateException("Apple Key ID가 설정되지 않았습니다. auth.apple.key-id를 확인하세요.");
+        }
+
+        if (isBlank(privateKey)) {
+            throw new IllegalStateException("Apple Private Key가 설정되지 않았습니다. auth.apple.private-key를 확인하세요.");
+        }
+
+        if (isBlank(redirectUri)) {
+            throw new IllegalStateException("Apple Redirect URI가 설정되지 않았습니다. auth.apple.redirect-uri를 확인하세요.");
+        }
+
+        log.info("[Apple Config] Apple 인증 설정 검증 완료 - Team: {}, Client: {}, Key: {}",
+                maskString(teamId), maskString(clientId), maskString(keyId));
+    }
+
+    /**
+     * 문자열이 비어있는지 확인합니다.
+     */
+    private boolean isBlank(String value) {
+        return value == null || value.trim().isEmpty();
+    }
+
+    /**
+     * 민감정보 로그에 출력할 때 마스킹 처리합니다.
+     */
+    private String maskString(String value) {
+        if (value == null || value.length() <= 4) {
+            return "****";
+        }
+        return value.substring(0, 4) + "****";
+    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
@@ -1,0 +1,31 @@
+package com.umc.puppymode2.domain.user.auth.config;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * Apple OAuth 인증을 위한 설정 클래스
+ * application.yml의 auth.apple 하위 설정값을 로드합니다.
+ */
+@Slf4j
+@Getter
+@Component
+public class AppleAuthConfig {
+
+    @Value("${auth.apple.team-id}")
+    private String teamId;
+
+    @Value("${auth.apple.client-id}")
+    private String clientId;
+
+    @Value("${auth.apple.key-id}")
+    private String keyId;
+
+    @Value("${auth.apple.private-key}")
+    private String privateKey;
+
+    @Value("${auth.apple.redirect-uri:https://puppy-mode.info/auth/apple/callback}")
+    private String redirectUri;
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -6,6 +6,7 @@ import com.umc.puppymode2.domain.user.auth.dto.AppleLoginRequestDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.auth.service.AppleAuthService;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.auth.context.UserContext;
 import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,6 +36,7 @@ public class AppleAuthController {
 
     private final AppleAuthService appleAuthService;
     private final ObjectMapper objectMapper;
+    private final UserContext userContext;
 
     /**
      * iOS 앱용 애플 로그인 엔드포인트
@@ -107,7 +109,7 @@ public class AppleAuthController {
     public ResponseEntity<ApiResponse<LoginResponseDTO>> appleWebCallback(
             @RequestParam Map<String, String> formParams) {
         try {
-            log.debug("[Apple Callback] 웹 요청: {}", formParams);
+            log.debug("[Apple Callback] 웹 요청 수신 - params: {}", formParams.keySet());
 
             if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
                 log.warn("[Apple Callback] 필수 파라미터 누락: {}", formParams);
@@ -176,7 +178,7 @@ public class AppleAuthController {
                         .body(ApiResponse.onFailure("COMMON401", "인증되지 않은 사용자입니다.", null));
             }
 
-            Long userId = Long.valueOf(authentication.getPrincipal().toString());
+            Long userId = userContext.getCurrentUserId();
 
             // Apple 회원탈퇴 처리 (토큰 무효화 + 사용자 삭제)
             appleAuthService.withdrawAppleUser(userId);

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -10,6 +10,7 @@ import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import com.umc.puppymode2.global.auth.context.UserContext;
 import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.exception.GeneralException;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -102,7 +103,7 @@ public class AppleAuthController {
 
         if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
             log.warn("[Apple Callback] 필수 파라미터 누락 - 존재하는 키: {}", formParams.keySet());
-            throw new IllegalArgumentException("필수 입력값이 누락되었습니다.");
+            throw new GeneralException(ErrorStatus.APPLE_MISSING_REQUIRED_FIELD);
         }
 
         String authorizationCode = formParams.get("code");

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -53,15 +53,6 @@ public class AppleAuthController {
                     **앱스토어 가이드라인 준수:**
                     - 이메일 제공 동의 없이도 로그인 가능
                     - Apple Refresh Token 관리
-                    
-                    **요청 예시:**
-                    ```json
-                    {
-                      "authorizationCode": "c1234567890abcdef...",
-                      "identityToken": "eyJhbGciOi...",
-                      "username": "홍길동"
-                    }
-                    ```
                     """
     )
     @ApiErrorCodeExamples({

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -1,0 +1,234 @@
+package com.umc.puppymode2.domain.user.auth.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.umc.puppymode2.domain.user.auth.dto.AppleLoginRequestDTO;
+import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
+import com.umc.puppymode2.domain.user.auth.service.AppleAuthService;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+/**
+ * Apple 로그인 컨트롤러
+ * <p>
+ * 1. Apple 소셜 로그인 구현
+ * 2. providerId(sub) 기반 사용자 식별
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth/apple")
+@Tag(name = "Apple Auth", description = "애플 로그인 API")
+public class AppleAuthController {
+
+    private final AppleAuthService appleAuthService;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * iOS 앱용 애플 로그인 엔드포인트
+     * JSON 요청을 받아 처리합니다.
+     */
+    @PostMapping("/login")
+    @Operation(
+            summary = "애플 로그인 (앱용)",
+            description = """
+                    애플 서버로부터 발급받은 Authorization Code와 Identity Token을 사용하여 JWT를 발급받습니다.
+                    
+                    **주요 기능:**
+                    - providerId(sub) 기반 사용자 식별 (이메일 미제공 시에도 로그인 가능)
+                    - 로그인 및 회원가입 자동 처리
+                    
+                    **앱스토어 가이드라인 준수:**
+                    - 이메일 제공 동의 없이도 로그인 가능
+                    - Apple Refresh Token 관리
+                    
+                    **요청 예시:**
+                    ```json
+                    {
+                      "authorizationCode": "c1234567890abcdef...",
+                      "identityToken": "eyJhbGciOi...",
+                      "username": "홍길동"
+                    }
+                    ```
+                    """
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus.APPLE_MISSING_REQUIRED_FIELD,
+            ErrorStatus.APPLE_AUTH_FAILED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> appleLogin(
+            @RequestBody @Valid AppleLoginRequestDTO request) {
+        try {
+            LoginResponseDTO response = appleAuthService.loginWithApple(
+                    request.getAuthorizationCode(),
+                    request.getIdentityToken(),
+                    request.getUsername()
+            );
+
+            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+
+        } catch (IllegalArgumentException e) {
+            // 로그에 자세히, 사용자 응답은 간단히
+            log.error("[Apple Login] 인증 실패 - 상세: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.onFailure("APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요.", null));
+
+        } catch (Exception e) {
+            // 로그에 스택트레이스, 응답은 일반
+            log.error("[Apple Login] 로그인 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.onFailure("COMMON500", "로그인 처리 중 오류가 발생했습니다.", null));
+        }
+    }
+
+    /**
+     * 웹 테스트용 애플 로그인 엔드포인트
+     * form_post 방식으로 전달되는 요청을 처리합니다.
+     */
+    @PostMapping("/callback")
+    @Operation(
+            summary = "애플 로그인 콜백 (웹 테스트용)",
+            description = """
+                    웹 방식으로 애플 로그인을 테스트합니다.
+                    Apple에서 form_post로 전달하는 데이터를 처리합니다.
+                    
+                    **개발/테스트 전용 엔드포인트입니다.**
+                    """
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus.APPLE_MISSING_REQUIRED_FIELD,
+            ErrorStatus.APPLE_AUTH_FAILED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    public ResponseEntity<ApiResponse<LoginResponseDTO>> appleWebCallback(
+            @RequestParam Map<String, String> formParams) {
+        try {
+            log.debug("[Apple Callback] 웹 요청: {}", formParams);
+
+            if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
+                log.warn("[Apple Callback] 필수 파라미터 누락: {}", formParams);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                        .body(ApiResponse.onFailure("APPLE4002",
+                                "필수 입력값이 누락되었습니다.", null));
+            }
+
+            String authorizationCode = formParams.get("code");
+            String identityToken = formParams.get("id_token");
+            String userJson = formParams.get("user");
+
+            // user JSON에서 이름 추출 (최초 로그인 시에만 제공됨)
+            String username = extractUsername(userJson);
+
+            LoginResponseDTO response = appleAuthService.loginWithApple(
+                    authorizationCode,
+                    identityToken,
+                    username
+            );
+
+            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+
+        } catch (IllegalArgumentException e) {
+            log.error("[Apple Callback] 인증 실패 - 상세: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(ApiResponse.onFailure("APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요.", null));
+
+        } catch (Exception e) {
+            log.error("[Apple Callback] 로그인 오류 발생", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.onFailure("COMMON500", "로그인 처리 중 오류가 발생했습니다.", null));
+        }
+    }
+
+    /**
+     * 애플 회원탈퇴
+     * Sign in with Apple 제공 시 계정 삭제 기능 필수
+     */
+    @DeleteMapping("/withdraw")
+    @Operation(
+            summary = "애플 회원탈퇴",
+            description = """
+                    애플 계정 연결을 해제하고 회원 정보를 삭제합니다.
+                    
+                    **앱스토어 가이드라인 필수:**
+                    - Sign in with Apple 제공 시 계정 삭제 기능 필수
+                    - Apple Refresh Token 무효화
+                    - 사용자 데이터 완전 삭제
+                    
+                    **처리 내용:**
+                    1. Apple Refresh Token 무효화
+                    2. 개인정보 마스킹
+                    3. 연관 데이터 삭제 (CASCADE)
+                    """
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus._UNAUTHORIZED,
+            ErrorStatus.APPLE_WITHDRAW_FAILED,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    public ResponseEntity<ApiResponse<String>> appleWithdraw(Authentication authentication) {
+        try {
+            if (authentication == null || authentication.getPrincipal() == null) {
+                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                        .body(ApiResponse.onFailure("COMMON401", "인증되지 않은 사용자입니다.", null));
+            }
+
+            Long userId = Long.valueOf(authentication.getPrincipal().toString());
+
+            // Apple 회원탈퇴 처리 (토큰 무효화 + 사용자 삭제)
+            appleAuthService.withdrawAppleUser(userId);
+
+            log.info("[Apple Withdraw] 회원탈퇴 성공 - userId: {}", userId);
+            return ResponseEntity.ok(ApiResponse.onSuccess("회원탈퇴가 완료되었습니다."));
+
+        } catch (Exception e) {
+            // 로그에는 자세히, 사용자에게는 간단히
+            log.error("[Apple Withdraw] 회원탈퇴 실패 - 상세: {}", e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(ApiResponse.onFailure("APPLE5001", "회원탈퇴 처리 중 오류가 발생했습니다.", null));
+        }
+    }
+
+    /**
+     * user JSON에서 username (firstName + lastName)을 추출합니다.
+     *
+     * @param userJson Apple이 제공하는 user 정보 JSON
+     * @return username (없으면 null)
+     */
+    private String extractUsername(String userJson) {
+        if (userJson == null || userJson.isEmpty()) {
+            return null;
+        }
+
+        try {
+            JsonNode userNode = objectMapper.readTree(userJson);
+            JsonNode nameNode = userNode.get("name");
+
+            if (nameNode == null) {
+                return null;
+            }
+
+            String firstName = nameNode.has("firstName") ? nameNode.get("firstName").asText() : "";
+            String lastName = nameNode.has("lastName") ? nameNode.get("lastName").asText() : "";
+
+            String username = (firstName + " " + lastName).trim();
+            return username.isEmpty() ? null : username;
+
+        } catch (Exception e) {
+            log.error("[Apple Callback] 사용자 정보 파싱 실패", e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -6,6 +6,7 @@ import com.umc.puppymode2.domain.user.auth.dto.AppleLoginRequestDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.auth.service.AppleAuthService;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import com.umc.puppymode2.global.auth.context.UserContext;
 import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
@@ -22,8 +23,7 @@ import java.util.Map;
 /**
  * Apple 로그인 컨트롤러
  * <p>
- * 1. Apple 소셜 로그인 구현
- * 2. providerId(sub) 기반 사용자 식별
+ * providerId(sub) 기반 사용자 식별로 이메일 제공 동의 없이도 로그인 가능
  */
 @Slf4j
 @RestController
@@ -38,7 +38,6 @@ public class AppleAuthController {
 
     /**
      * iOS 앱용 애플 로그인 엔드포인트
-     * JSON 요청을 받아 처리합니다.
      */
     @PostMapping("/login")
     @Operation(
@@ -53,6 +52,8 @@ public class AppleAuthController {
                     **앱스토어 가이드라인 준수:**
                     - 이메일 제공 동의 없이도 로그인 가능
                     - Apple Refresh Token 관리
+                    
+                    **주의:** Redis 서버 장애 시 refreshToken 없이 로그인됩니다.
                     """
     )
     @ApiErrorCodeExamples({
@@ -69,12 +70,15 @@ public class AppleAuthController {
                 request.getUsername()
         );
 
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                response,
+                SuccessStatus.AUTH_APPLE_LOGIN_SUCCESS.getCode(),
+                SuccessStatus.AUTH_APPLE_LOGIN_SUCCESS.getMessage()
+        ));
     }
 
     /**
      * 웹 테스트용 애플 로그인 엔드포인트
-     * form_post 방식으로 전달되는 요청을 처리합니다.
      */
     @PostMapping("/callback")
     @Operation(
@@ -97,7 +101,7 @@ public class AppleAuthController {
         log.debug("[Apple Callback] 웹 요청 수신 - params: {}", formParams.keySet());
 
         if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
-            log.warn("[Apple Callback] 필수 파라미터 누락: {}", formParams);
+            log.warn("[Apple Callback] 필수 파라미터 누락 - 존재하는 키: {}", formParams.keySet());
             throw new IllegalArgumentException("필수 입력값이 누락되었습니다.");
         }
 
@@ -119,7 +123,7 @@ public class AppleAuthController {
 
     /**
      * 애플 회원탈퇴
-     * Sign in with Apple 제공 시 계정 삭제 기능 필수
+     * 계정 삭제 기능 제공
      */
     @DeleteMapping("/withdraw")
     @Operation(
@@ -130,17 +134,18 @@ public class AppleAuthController {
                     **앱스토어 가이드라인 필수:**
                     - Sign in with Apple 제공 시 계정 삭제 기능 필수
                     - Apple Refresh Token 무효화
-                    - 사용자 데이터 완전 삭제
+                    - 사용자 데이터 완전 삭제 (항상 실행)
                     
                     **처리 내용:**
-                    1. Apple Refresh Token 무효화
-                    2. 개인정보 마스킹
+                    1. Apple Refresh Token 무효화 시도
+                    2. 사용자 데이터 삭제 (항상 실행)
                     3. 연관 데이터 삭제 (CASCADE)
+                    
+                    Apple 서버 장애 시에도 사용자 탈퇴는 정상 처리됩니다.
                     """
     )
     @ApiErrorCodeExamples({
             ErrorStatus._UNAUTHORIZED,
-            ErrorStatus.APPLE_WITHDRAW_FAILED,
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
     public ResponseEntity<ApiResponse<String>> appleWithdraw() {

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AppleAuthController.java
@@ -14,9 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -64,27 +62,14 @@ public class AppleAuthController {
     })
     public ResponseEntity<ApiResponse<LoginResponseDTO>> appleLogin(
             @RequestBody @Valid AppleLoginRequestDTO request) {
-        try {
-            LoginResponseDTO response = appleAuthService.loginWithApple(
-                    request.getAuthorizationCode(),
-                    request.getIdentityToken(),
-                    request.getUsername()
-            );
 
-            return ResponseEntity.ok(ApiResponse.onSuccess(response));
+        LoginResponseDTO response = appleAuthService.loginWithApple(
+                request.getAuthorizationCode(),
+                request.getIdentityToken(),
+                request.getUsername()
+        );
 
-        } catch (IllegalArgumentException e) {
-            // 로그에 자세히, 사용자 응답은 간단히
-            log.error("[Apple Login] 인증 실패 - 상세: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.onFailure("APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요.", null));
-
-        } catch (Exception e) {
-            // 로그에 스택트레이스, 응답은 일반
-            log.error("[Apple Login] 로그인 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.onFailure("COMMON500", "로그인 처리 중 오류가 발생했습니다.", null));
-        }
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     /**
@@ -108,41 +93,28 @@ public class AppleAuthController {
     })
     public ResponseEntity<ApiResponse<LoginResponseDTO>> appleWebCallback(
             @RequestParam Map<String, String> formParams) {
-        try {
-            log.debug("[Apple Callback] 웹 요청 수신 - params: {}", formParams.keySet());
 
-            if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
-                log.warn("[Apple Callback] 필수 파라미터 누락: {}", formParams);
-                return ResponseEntity.status(HttpStatus.BAD_REQUEST)
-                        .body(ApiResponse.onFailure("APPLE4002",
-                                "필수 입력값이 누락되었습니다.", null));
-            }
+        log.debug("[Apple Callback] 웹 요청 수신 - params: {}", formParams.keySet());
 
-            String authorizationCode = formParams.get("code");
-            String identityToken = formParams.get("id_token");
-            String userJson = formParams.get("user");
-
-            // user JSON에서 이름 추출 (최초 로그인 시에만 제공됨)
-            String username = extractUsername(userJson);
-
-            LoginResponseDTO response = appleAuthService.loginWithApple(
-                    authorizationCode,
-                    identityToken,
-                    username
-            );
-
-            return ResponseEntity.ok(ApiResponse.onSuccess(response));
-
-        } catch (IllegalArgumentException e) {
-            log.error("[Apple Callback] 인증 실패 - 상세: {}", e.getMessage());
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                    .body(ApiResponse.onFailure("APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요.", null));
-
-        } catch (Exception e) {
-            log.error("[Apple Callback] 로그인 오류 발생", e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.onFailure("COMMON500", "로그인 처리 중 오류가 발생했습니다.", null));
+        if (!formParams.containsKey("code") || !formParams.containsKey("id_token")) {
+            log.warn("[Apple Callback] 필수 파라미터 누락: {}", formParams);
+            throw new IllegalArgumentException("필수 입력값이 누락되었습니다.");
         }
+
+        String authorizationCode = formParams.get("code");
+        String identityToken = formParams.get("id_token");
+        String userJson = formParams.get("user");
+
+        // user JSON에서 이름 추출 (최초 로그인 시에만 제공됨)
+        String username = extractUsername(userJson);
+
+        LoginResponseDTO response = appleAuthService.loginWithApple(
+                authorizationCode,
+                identityToken,
+                username
+        );
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 
     /**
@@ -171,27 +143,15 @@ public class AppleAuthController {
             ErrorStatus.APPLE_WITHDRAW_FAILED,
             ErrorStatus._INTERNAL_SERVER_ERROR
     })
-    public ResponseEntity<ApiResponse<String>> appleWithdraw(Authentication authentication) {
-        try {
-            if (authentication == null || authentication.getPrincipal() == null) {
-                return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
-                        .body(ApiResponse.onFailure("COMMON401", "인증되지 않은 사용자입니다.", null));
-            }
+    public ResponseEntity<ApiResponse<String>> appleWithdraw() {
 
-            Long userId = userContext.getCurrentUserId();
+        Long userId = userContext.getCurrentUserId();
 
-            // Apple 회원탈퇴 처리 (토큰 무효화 + 사용자 삭제)
-            appleAuthService.withdrawAppleUser(userId);
+        // Apple 회원탈퇴 처리 (토큰 무효화 + 사용자 삭제)
+        appleAuthService.withdrawAppleUser(userId);
 
-            log.info("[Apple Withdraw] 회원탈퇴 성공 - userId: {}", userId);
-            return ResponseEntity.ok(ApiResponse.onSuccess("회원탈퇴가 완료되었습니다."));
-
-        } catch (Exception e) {
-            // 로그에는 자세히, 사용자에게는 간단히
-            log.error("[Apple Withdraw] 회원탈퇴 실패 - 상세: {}", e.getMessage(), e);
-            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-                    .body(ApiResponse.onFailure("APPLE5001", "회원탈퇴 처리 중 오류가 발생했습니다.", null));
-        }
+        log.info("[Apple Withdraw] 회원탈퇴 성공 - userId: {}", userId);
+        return ResponseEntity.ok(ApiResponse.onSuccess("회원탈퇴가 완료되었습니다."));
     }
 
     /**

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AppleLoginRequestDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AppleLoginRequestDTO.java
@@ -1,0 +1,32 @@
+package com.umc.puppymode2.domain.user.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * Apple 로그인 요청 DTO
+ * 클라이언트에서 전달받는 Apple 인증 정보
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Schema(description = "애플 로그인 요청")
+public class AppleLoginRequestDTO {
+
+    @NotBlank(message = "Authorization Code는 필수입니다.")
+    @Schema(description = "애플 Authorization Code", example = "c1234567890abcdef...", required = true)
+    private String authorizationCode;
+
+    @NotBlank(message = "Identity Token은 필수입니다.")
+    @Schema(description = "애플 Identity Token (JWT)", example = "eyJhbGciOi...", required = true)
+    private String identityToken;
+
+    @Schema(description = "사용자 이름 (선택 사항, 최초 로그인 시에만 제공됨)", example = "홍길동")
+    private String username;
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/ApplePublicKeysDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/ApplePublicKeysDTO.java
@@ -1,0 +1,41 @@
+package com.umc.puppymode2.domain.user.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * Apple Public Keys 응답 DTO
+ * Apple의 /auth/keys 엔드포인트로부터 받는 공개키 목록
+ */
+@Getter
+@NoArgsConstructor
+public class ApplePublicKeysDTO {
+
+    @JsonProperty("keys")
+    private List<Key> keys;
+
+    @Getter
+    @NoArgsConstructor
+    public static class Key {
+        @JsonProperty("kty")
+        private String kty;
+
+        @JsonProperty("kid")
+        private String kid;
+
+        @JsonProperty("use")
+        private String use;
+
+        @JsonProperty("alg")
+        private String alg;
+
+        @JsonProperty("n")
+        private String n;
+
+        @JsonProperty("e")
+        private String e;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AppleTokenResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AppleTokenResponseDTO.java
@@ -1,0 +1,31 @@
+package com.umc.puppymode2.domain.user.auth.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Apple Token API 응답 DTO
+ * Apple의 /auth/token 엔드포인트로부터 받는 응답
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class AppleTokenResponseDTO {
+
+    @JsonProperty("access_token")
+    private String accessToken;
+
+    @JsonProperty("token_type")
+    private String tokenType;
+
+    @JsonProperty("expires_in")
+    private Long expiresIn;
+
+    @JsonProperty("refresh_token")
+    private String refreshToken;
+
+    @JsonProperty("id_token")
+    private String idToken;
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/enums/Provider.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/enums/Provider.java
@@ -1,5 +1,6 @@
 package com.umc.puppymode2.domain.user.auth.enums;
 
 public enum Provider {
-    KAKAO
+    KAKAO,
+    APPLE
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -3,8 +3,8 @@ package com.umc.puppymode2.domain.user.auth.service;
 import com.umc.puppymode2.domain.user.auth.dto.ApplePublicKeysDTO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -16,11 +16,18 @@ import java.util.Map;
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 public class AppleAuthQueryService {
 
     private final WebClient webClient;
     private final ApplePublicKeyUtil applePublicKeyUtil;
+
+    public AppleAuthQueryService(
+            @Qualifier("appleWebClient") WebClient webClient,
+            ApplePublicKeyUtil applePublicKeyUtil
+    ) {
+        this.webClient = webClient;
+        this.applePublicKeyUtil = applePublicKeyUtil;
+    }
 
     private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
 

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -1,7 +1,11 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.puppymode2.domain.user.auth.config.AppleAuthConfig;
 import com.umc.puppymode2.domain.user.auth.dto.ApplePublicKeysDTO;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.extern.slf4j.Slf4j;
@@ -10,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.security.PublicKey;
+import java.util.Base64;
 import java.util.Map;
 
 /**
@@ -18,6 +23,9 @@ import java.util.Map;
 @Slf4j
 @Service
 public class AppleAuthQueryService {
+
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
 
     private final WebClient webClient;
     private final ApplePublicKeyUtil applePublicKeyUtil;
@@ -33,8 +41,6 @@ public class AppleAuthQueryService {
         this.appleAuthConfig = appleAuthConfig;
     }
 
-    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
-
     /**
      * Apple Identity Token을 검증합니다.
      *
@@ -49,7 +55,8 @@ public class AppleAuthQueryService {
             String alg = headers.get("alg");
 
             if (kid == null || alg == null) {
-                throw new IllegalArgumentException("Identity Token의 헤더에 kid 또는 alg가 없습니다.");
+                log.error("[Apple Auth] Identity Token 헤더에 kid 또는 alg가 없음");
+                throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
             }
 
             // Apple Public Keys 가져오기
@@ -59,7 +66,10 @@ public class AppleAuthQueryService {
             ApplePublicKeysDTO.Key matchedKey = publicKeys.getKeys().stream()
                     .filter(key -> key.getKid().equals(kid))
                     .findFirst()
-                    .orElseThrow(() -> new IllegalArgumentException("일치하는 Apple 공개키를 찾을 수 없습니다."));
+                    .orElseThrow(() -> {
+                        log.error("[Apple Auth] 일치하는 Apple 공개키를 찾을 수 없음 - kid: {}", kid);
+                        return new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
+                    });
 
             // PublicKey 생성
             PublicKey publicKey = applePublicKeyUtil.generatePublicKey(matchedKey);
@@ -76,9 +86,14 @@ public class AppleAuthQueryService {
             log.info("[Apple Auth] Identity Token 검증 완료 - sub: {}", claims.getSubject());
             return claims;
 
+        } catch (GeneralException e) {
+            throw e;
+        } catch (io.jsonwebtoken.JwtException e) {
+            log.error("[Apple Auth] JWT 검증 실패", e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         } catch (Exception e) {
-            log.error("[Apple Auth] Identity Token 검증 실패", e);
-            throw new IllegalArgumentException("Invalid Apple Identity Token", e);
+            log.error("[Apple Auth] Identity Token 검증 중 예외 발생", e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
     }
 
@@ -88,20 +103,26 @@ public class AppleAuthQueryService {
     private Map<String, String> parseHeaders(String identityToken) {
         try {
             String[] chunks = identityToken.split("\\.");
-            String header = new String(java.util.Base64.getUrlDecoder().decode(chunks[0]));
+            if (chunks.length < 2) {
+                throw new IllegalArgumentException("Invalid JWT format");
+            }
 
-            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
-            return mapper.readValue(header, Map.class);
+            byte[] decodedBytes = Base64.getUrlDecoder().decode(chunks[0]);
+            String header = new String(decodedBytes);
+
+            return OBJECT_MAPPER.readValue(header, new TypeReference<Map<String, String>>() {
+            });
 
         } catch (Exception e) {
             log.error("[Apple Auth] Identity Token 헤더 파싱 실패", e);
-            throw new RuntimeException("Failed to parse Identity Token header", e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
     }
 
     /**
      * Apple의 공개키 목록을 가져옵니다.
      */
+    //TODO: 성능 개선을 위해 캐싱 추가 - 공개키는 자주 변경되지 않으므로 TTL과 함께 캐싱
     private ApplePublicKeysDTO getApplePublicKeys() {
         try {
             ApplePublicKeysDTO keys = webClient.get()
@@ -111,14 +132,17 @@ public class AppleAuthQueryService {
                     .block();
 
             if (keys == null || keys.getKeys().isEmpty()) {
-                throw new RuntimeException("Apple 공개키를 가져오지 못했습니다.");
+                log.error("[Apple Auth] Apple 공개키 응답이 비어있음");
+                throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
             }
 
             return keys;
 
+        } catch (GeneralException e) {
+            throw e;
         } catch (Exception e) {
             log.error("[Apple Auth] Apple 공개키 조회 실패", e);
-            throw new RuntimeException("Failed to fetch Apple public keys", e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -129,6 +129,7 @@ public class AppleAuthQueryService {
                     .uri(APPLE_PUBLIC_KEYS_URL)
                     .retrieve()
                     .bodyToMono(ApplePublicKeysDTO.class)
+                    .timeout(java.time.Duration.ofSeconds(15))
                     .block();
 
             if (keys == null || keys.getKeys().isEmpty()) {
@@ -138,8 +139,6 @@ public class AppleAuthQueryService {
 
             return keys;
 
-        } catch (GeneralException e) {
-            throw e;
         } catch (Exception e) {
             log.error("[Apple Auth] Apple 공개키 조회 실패", e);
             throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -1,5 +1,6 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
+import com.umc.puppymode2.domain.user.auth.config.AppleAuthConfig;
 import com.umc.puppymode2.domain.user.auth.dto.ApplePublicKeysDTO;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
@@ -20,13 +21,16 @@ public class AppleAuthQueryService {
 
     private final WebClient webClient;
     private final ApplePublicKeyUtil applePublicKeyUtil;
+    private final AppleAuthConfig appleAuthConfig;
 
     public AppleAuthQueryService(
             @Qualifier("appleWebClient") WebClient webClient,
-            ApplePublicKeyUtil applePublicKeyUtil
+            ApplePublicKeyUtil applePublicKeyUtil,
+            AppleAuthConfig appleAuthConfig
     ) {
         this.webClient = webClient;
         this.applePublicKeyUtil = applePublicKeyUtil;
+        this.appleAuthConfig = appleAuthConfig;
     }
 
     private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
@@ -63,6 +67,8 @@ public class AppleAuthQueryService {
             // Identity Token 검증 및 Claims 추출
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(publicKey)
+                    .requireIssuer("https://appleid.apple.com")
+                    .requireAudience(appleAuthConfig.getClientId())
                     .build()
                     .parseClaimsJws(identityToken)
                     .getBody();

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -1,0 +1,111 @@
+package com.umc.puppymode2.domain.user.auth.service;
+
+import com.umc.puppymode2.domain.user.auth.dto.ApplePublicKeysDTO;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.security.PublicKey;
+import java.util.Map;
+
+/**
+ * Apple Identity Token을 검증하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleAuthQueryService {
+
+    private final WebClient webClient;
+    private final ApplePublicKeyUtil applePublicKeyUtil;
+
+    private static final String APPLE_PUBLIC_KEYS_URL = "https://appleid.apple.com/auth/keys";
+
+    /**
+     * Apple Identity Token을 검증합니다.
+     *
+     * @param identityToken Apple로부터 받은 Identity Token (JWT)
+     * @return JWT Claims (사용자 정보 포함)
+     */
+    public Claims verifyIdentityToken(String identityToken) {
+        try {
+            // Identity Token의 Header에서 kid 추출
+            Map<String, String> headers = parseHeaders(identityToken);
+            String kid = headers.get("kid");
+            String alg = headers.get("alg");
+
+            if (kid == null || alg == null) {
+                throw new IllegalArgumentException("Identity Token의 헤더에 kid 또는 alg가 없습니다.");
+            }
+
+            // Apple Public Keys 가져오기
+            ApplePublicKeysDTO publicKeys = getApplePublicKeys();
+
+            // kid가 일치하는 공개키 찾기
+            ApplePublicKeysDTO.Key matchedKey = publicKeys.getKeys().stream()
+                    .filter(key -> key.getKid().equals(kid))
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException("일치하는 Apple 공개키를 찾을 수 없습니다."));
+
+            // PublicKey 생성
+            PublicKey publicKey = applePublicKeyUtil.generatePublicKey(matchedKey);
+
+            // Identity Token 검증 및 Claims 추출
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(publicKey)
+                    .build()
+                    .parseClaimsJws(identityToken)
+                    .getBody();
+
+            log.info("[Apple Auth] Identity Token 검증 완료 - sub: {}", claims.getSubject());
+            return claims;
+
+        } catch (Exception e) {
+            log.error("[Apple Auth] Identity Token 검증 실패", e);
+            throw new IllegalArgumentException("Invalid Apple Identity Token", e);
+        }
+    }
+
+    /**
+     * Identity Token의 Header를 파싱합니다.
+     */
+    private Map<String, String> parseHeaders(String identityToken) {
+        try {
+            String[] chunks = identityToken.split("\\.");
+            String header = new String(java.util.Base64.getUrlDecoder().decode(chunks[0]));
+
+            com.fasterxml.jackson.databind.ObjectMapper mapper = new com.fasterxml.jackson.databind.ObjectMapper();
+            return mapper.readValue(header, Map.class);
+
+        } catch (Exception e) {
+            log.error("[Apple Auth] Identity Token 헤더 파싱 실패", e);
+            throw new RuntimeException("Failed to parse Identity Token header", e);
+        }
+    }
+
+    /**
+     * Apple의 공개키 목록을 가져옵니다.
+     */
+    private ApplePublicKeysDTO getApplePublicKeys() {
+        try {
+            ApplePublicKeysDTO keys = webClient.get()
+                    .uri(APPLE_PUBLIC_KEYS_URL)
+                    .retrieve()
+                    .bodyToMono(ApplePublicKeysDTO.class)
+                    .block();
+
+            if (keys == null || keys.getKeys().isEmpty()) {
+                throw new RuntimeException("Apple 공개키를 가져오지 못했습니다.");
+            }
+
+            return keys;
+
+        } catch (Exception e) {
+            log.error("[Apple Auth] Apple 공개키 조회 실패", e);
+            throw new RuntimeException("Failed to fetch Apple public keys", e);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -1,0 +1,254 @@
+package com.umc.puppymode2.domain.user.auth.service;
+
+import com.umc.puppymode2.domain.user.auth.config.AppleAuthConfig;
+import com.umc.puppymode2.domain.user.auth.dto.AppleTokenResponseDTO;
+import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
+import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.domain.user.auth.enums.Provider;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.security.PrivateKey;
+
+/**
+ * Apple 로그인 처리 메인 서비스
+ *
+ * 앱스토어 출시를 위한 완성도 높은 구현:
+ * 1. providerId(sub) 기반 사용자 식별
+ * 2. 이메일 제공 동의 없이도 처리 가능
+ * 3. 로그아웃/회원탈퇴 지원
+ * 4. Refresh Token 관리
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AppleAuthService {
+
+    private final WebClient webClient;
+    private final AppleKeyService appleKeyService;
+    private final AppleAuthQueryService appleAuthQueryService;
+    private final UserAuthService userAuthService;
+    private final AppleAuthConfig appleAuthConfig;
+
+    private static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
+    private static final String APPLE_REVOKE_URL = "https://appleid.apple.com/auth/revoke";
+
+    /**
+     * Apple 로그인을 처리합니다.
+     * providerId(sub)로 사용자를 식별하여 이메일 없이도 로그인 가능합니다.
+     *
+     * @param authorizationCode Apple Authorization Code
+     * @param identityToken Apple Identity Token (JWT)
+     * @param username 사용자 이름 (선택)
+     * @return 로그인 응답 (JWT 토큰 포함)
+     */
+    public LoginResponseDTO loginWithApple(String authorizationCode, String identityToken,
+                                           String username) {
+        // 1. Identity Token 검증 및 사용자 정보 추출
+        Claims claims = appleAuthQueryService.verifyIdentityToken(identityToken);
+        if (claims == null) {
+            throw new IllegalArgumentException("Invalid Apple Identity Token");
+        }
+
+        // 2. providerId(sub) 추출 - 이것이 Apple의 고유 사용자 식별자
+        String providerId = claims.getSubject();
+        String email = claims.get("email", String.class);
+
+        // 이메일이 없는 경우 더미 이메일 생성 (providerId 기반)
+        if (email == null || email.isEmpty()) {
+            email = "apple_" + providerId + "@private.com";
+            log.info("[Apple Login] 이메일 미제공 - 더미 이메일 생성: {}", email);
+        }
+
+        // 3. Apple Token 발급 (Refresh Token 포함)
+        AppleTokenResponseDTO appleTokens = getAppleTokens(authorizationCode);
+        String appleRefreshToken = appleTokens.getRefreshToken();
+
+        // 4. 사용자 정보 DTO 생성
+        UserAuthInfoDTO userInfo = UserAuthInfoDTO.builder()
+                .providerId(providerId)  // sub 값 저장
+                .email(email)
+                .username(username)
+                .build();
+
+        // 5. 사용자 생성 또는 업데이트 (providerId 기반)
+        LoginResponseDTO loginResponse = userAuthService.createOrUpdateUser(
+                userInfo, Provider.APPLE, appleRefreshToken);
+
+        log.info("[Apple Login] 로그인 성공 - providerId: {}, isNewUser: {}",
+                providerId, loginResponse.getUserInfo().getIsNewUser());
+
+        return loginResponse;
+    }
+
+    /**
+     * Authorization Code를 사용하여 Apple Access Token과 Refresh Token을 발급받습니다.
+     *
+     * @param authorizationCode Apple Authorization Code
+     * @return Apple Token 응답
+     */
+    private AppleTokenResponseDTO getAppleTokens(String authorizationCode) {
+        if (authorizationCode == null || authorizationCode.trim().isEmpty()) {
+            throw new IllegalArgumentException("Authorization Code가 비어 있습니다.");
+        }
+
+        // Client Secret 생성
+        String clientSecret = generateClientSecret();
+        String clientId = appleAuthConfig.getClientId();
+        String redirectUri = appleAuthConfig.getRedirectUri();
+
+        try {
+            AppleTokenResponseDTO response = webClient.post()
+                    .uri(APPLE_TOKEN_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("code", authorizationCode)
+                            .with("grant_type", "authorization_code")
+                            .with("redirect_uri", redirectUri))
+                    .retrieve()
+                    .onStatus(status -> status.is4xxClientError(), clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .doOnNext(errorBody -> log.error("[Apple Token] 4xx 에러: {}", errorBody))
+                                    .flatMap(errorBody -> Mono.error(new IllegalArgumentException(
+                                            "Apple Token 발급 실패 (4xx): " + errorBody)))
+                    )
+                    .onStatus(status -> status.is5xxServerError(), clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .doOnNext(errorBody -> log.error("[Apple Token] 5xx 에러: {}", errorBody))
+                                    .flatMap(errorBody -> Mono.error(new RuntimeException(
+                                            "Apple 서버 오류 (5xx): " + errorBody)))
+                    )
+                    .bodyToMono(AppleTokenResponseDTO.class)
+                    .block();
+
+            if (response == null || response.getAccessToken() == null) {
+                throw new RuntimeException("Apple Token 발급 실패: 응답 없음");
+            }
+
+            log.info("[Apple Token] 토큰 발급 성공");
+            return response;
+
+        } catch (Exception e) {
+            log.error("[Apple Token] 토큰 발급 중 예외 발생", e);
+            throw new RuntimeException("Apple Token 발급 실패: " + e.getMessage(), e);
+        }
+    }
+
+    /**
+     * Client Secret을 생성합니다.
+     * Apple은 ES256 알고리즘으로 서명된 JWT를 Client Secret으로 요구합니다.
+     *
+     * @return Client Secret (JWT)
+     */
+    private String generateClientSecret() {
+        try {
+            long now = System.currentTimeMillis();
+            long exp = now + (15777000 * 1000L); // 약 6개월 후 만료
+
+            PrivateKey privateKey = appleKeyService.getPrivateKey();
+            if (privateKey == null) {
+                throw new IllegalStateException("Private Key가 null입니다.");
+            }
+
+            String clientId = appleAuthConfig.getClientId();
+            String keyId = appleAuthConfig.getKeyId();
+            String teamId = appleAuthConfig.getTeamId();
+
+            if (clientId == null || keyId == null || teamId == null) {
+                throw new IllegalStateException("Apple 설정값(clientId, keyId, teamId)이 null입니다.");
+            }
+
+            String clientSecret = Jwts.builder()
+                    .setHeaderParam("alg", "ES256")
+                    .setHeaderParam("kid", keyId)
+                    .setIssuer(teamId)
+                    .setIssuedAt(new java.util.Date(now))
+                    .setExpiration(new java.util.Date(exp))
+                    .setAudience("https://appleid.apple.com")
+                    .setSubject(clientId)
+                    .signWith(privateKey, io.jsonwebtoken.SignatureAlgorithm.ES256)
+                    .compact();
+
+            log.debug("[Apple Auth] Client Secret 생성 완료");
+            return clientSecret;
+
+        } catch (Exception e) {
+            log.error("[Apple Auth] Client Secret 생성 실패", e);
+            throw new RuntimeException("Apple Client Secret 생성 실패", e);
+        }
+    }
+
+    /**
+     * Apple 회원탈퇴 처리
+     * 앱스토어 가이드라인 준수를 위해 구현
+     *
+     * @param userId 사용자 ID
+     */
+    @Transactional
+    public void withdrawAppleUser(Long userId) {
+        try {
+            // 1. Apple Refresh Token 무효화
+            String appleRefreshToken = userAuthService.getAppleRefreshToken(userId);
+
+            if (appleRefreshToken != null) {
+                revokeAppleToken(appleRefreshToken);
+                log.info("[Apple Withdraw] Apple 토큰 무효화 완료 - userId: {}", userId);
+            } else {
+                log.warn("[Apple Withdraw] Apple Refresh Token 없음 - userId: {}", userId);
+            }
+
+            // 2. 사용자 탈퇴 처리 (UserService에서 처리)
+            userAuthService.withdrawUser(userId);
+
+            log.info("[Apple Withdraw] 회원탈퇴 완료 - userId: {}", userId);
+
+        } catch (Exception e) {
+            log.error("[Apple Withdraw] 회원탈퇴 처리 실패 - userId: " + userId, e);
+            throw new RuntimeException("회원탈퇴 처리 중 오류가 발생했습니다.", e);
+        }
+    }
+
+    /**
+     * Apple Refresh Token을 무효화합니다.
+     *
+     * @param refreshToken Apple Refresh Token
+     */
+    private void revokeAppleToken(String refreshToken) {
+        try {
+            String clientSecret = generateClientSecret();
+            String clientId = appleAuthConfig.getClientId();
+
+            webClient.post()
+                    .uri(APPLE_REVOKE_URL)
+                    .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+                    .body(BodyInserters.fromFormData("client_id", clientId)
+                            .with("client_secret", clientSecret)
+                            .with("token", refreshToken)
+                            .with("token_type_hint", "refresh_token"))
+                    .retrieve()
+                    .onStatus(status -> status.isError(), clientResponse ->
+                            clientResponse.bodyToMono(String.class)
+                                    .doOnNext(errorBody -> log.error("[Apple Revoke] 에러: {}", errorBody))
+                                    .then(Mono.empty())
+                    )
+                    .bodyToMono(Void.class)
+                    .block();
+
+            log.info("[Apple Revoke] Apple 토큰 무효화 성공");
+
+        } catch (Exception e) {
+            log.error("[Apple Revoke] Apple 토큰 무효화 실패", e);
+            throw new RuntimeException("Apple 토큰 무효화 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -206,32 +206,36 @@ public class AppleAuthService {
 
     /**
      * Apple 회원탈퇴 처리
-     * 앱스토어 가이드라인 준수를 위해 구현
+     * <p>
+     * 사용자 탈퇴 보장
+     * - Apple 토큰 무효화는 best effort로 시도
+     * - revoke 실패 시에도 사용자 삭제는 진행
      *
      * @param userId 사용자 ID
      */
     @Transactional
     public void withdrawAppleUser(Long userId) {
-        try {
-            // 1. Apple Refresh Token 무효화
-            String appleRefreshToken = userAuthService.getAppleRefreshToken(userId);
+        // 1. Apple Refresh Token 무효화 시도
+        String appleRefreshToken = userAuthService.getAppleRefreshToken(userId);
 
-            if (appleRefreshToken != null) {
+        if (appleRefreshToken != null) {
+            try {
                 revokeAppleToken(appleRefreshToken);
                 log.info("[Apple Withdraw] Apple 토큰 무효화 완료 - userId: {}", userId);
-            } else {
-                log.warn("[Apple Withdraw] Apple Refresh Token 없음 - userId: {}", userId);
+            } catch (Exception e) {
+                // Apple 서버 장애 등으로 실패해도 탈퇴는 진행
+                // 토큰은 60일 후 자동 만료, 사용자 데이터 삭제
+                log.error("[Apple Withdraw] Apple 토큰 무효화 실패 (사용자 탈퇴는 진행) - userId: {}, error: {}",
+                        userId, e.getMessage(), e);
             }
-
-            // 2. 사용자 탈퇴 처리 (UserService에서 처리)
-            userAuthService.withdrawUser(userId);
-
-            log.info("[Apple Withdraw] 회원탈퇴 완료 - userId: {}", userId);
-
-        } catch (Exception e) {
-            log.error("[Apple Withdraw] 회원탈퇴 처리 실패 - userId: " + userId, e);
-            throw new RuntimeException("회원탈퇴 처리 중 오류가 발생했습니다.", e);
+        } else {
+            log.warn("[Apple Withdraw] Apple Refresh Token 없음 - userId: {}", userId);
         }
+
+        // 2. 사용자 탈퇴 처리 (반드시 실행됨)
+        userAuthService.withdrawUser(userId);
+
+        log.info("[Apple Withdraw] 회원탈퇴 완료 - userId: {}", userId);
     }
 
     /**

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -142,6 +142,7 @@ public class AppleAuthService {
                                             ErrorStatus.APPLE_AUTH_FAILED)))
                     )
                     .bodyToMono(AppleTokenResponseDTO.class)
+                    .timeout(java.time.Duration.ofSeconds(30))
                     .block();
 
             if (response == null || response.getAccessToken() == null) {
@@ -262,6 +263,7 @@ public class AppleAuthService {
                                             "Apple 토큰 무효화 실패: " + errorBody)))
                     )
                     .bodyToMono(Void.class)
+                    .timeout(java.time.Duration.ofSeconds(15))
                     .block();
 
             log.info("[Apple Revoke] Apple 토큰 무효화 성공");

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -79,7 +79,7 @@ public class AppleAuthService {
         // 이메일이 없는 경우 더미 이메일 생성 (providerId 기반)
         if (email == null || email.isEmpty()) {
             email = "apple_" + providerId + "@private.com";
-            log.info("[Apple Login] 이메일 미제공 - 더미 이메일 생성: {}", email);
+            log.info("[Apple Login] 이메일 미제공 - 더미 이메일 생성");
         }
 
         // 3. Apple Token 발급 (Refresh Token 포함)

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -9,7 +9,6 @@ import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.exception.GeneralException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
@@ -20,6 +19,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
 import java.security.PrivateKey;
+import java.util.UUID;
 
 /**
  * Apple 로그인 처리 메인 서비스
@@ -70,18 +70,14 @@ public class AppleAuthService {
                                            String username) {
         // 1. Identity Token 검증 및 사용자 정보 추출
         Claims claims = appleAuthQueryService.verifyIdentityToken(identityToken);
-        if (claims == null) {
-            log.error("[Apple Login] Identity Token 검증 실패");
-            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
-        }
 
         // 2. providerId(sub) 추출 - Apple의 고유 사용자 식별자
         String providerId = claims.getSubject();
         String email = claims.get("email", String.class);
 
-        // 이메일이 없는 경우 더미 이메일 생성 (providerId 기반)
+        // 이메일이 없는 경우 더미 이메일 생성 (UUID 기반으로 프라이버시 보호)
         if (email == null || email.isEmpty()) {
-            email = "apple_" + providerId + "@private.com";
+            email = "apple_" + UUID.randomUUID().toString() + "@private.com";
             log.info("[Apple Login] 이메일 미제공 - 더미 이메일 생성");
         }
 
@@ -114,7 +110,8 @@ public class AppleAuthService {
      */
     private AppleTokenResponseDTO getAppleTokens(String authorizationCode) {
         if (authorizationCode == null || authorizationCode.trim().isEmpty()) {
-            throw new IllegalArgumentException("Authorization Code가 비어 있습니다.");
+            log.error("[Apple Token] Authorization Code가 비어있음");
+            throw new GeneralException(ErrorStatus.APPLE_MISSING_REQUIRED_FIELD);
         }
 
         // Client Secret 생성
@@ -135,28 +132,31 @@ public class AppleAuthService {
                     .onStatus(status -> status.is4xxClientError(), clientResponse ->
                             clientResponse.bodyToMono(String.class)
                                     .doOnNext(errorBody -> log.error("[Apple Token] 4xx 에러: {}", errorBody))
-                                    .flatMap(errorBody -> Mono.error(new IllegalArgumentException(
-                                            "Apple Token 발급 실패 (4xx): " + errorBody)))
+                                    .flatMap(errorBody -> Mono.error(new GeneralException(
+                                            ErrorStatus.APPLE_AUTH_FAILED)))
                     )
                     .onStatus(status -> status.is5xxServerError(), clientResponse ->
                             clientResponse.bodyToMono(String.class)
                                     .doOnNext(errorBody -> log.error("[Apple Token] 5xx 에러: {}", errorBody))
-                                    .flatMap(errorBody -> Mono.error(new RuntimeException(
-                                            "Apple 서버 오류 (5xx): " + errorBody)))
+                                    .flatMap(errorBody -> Mono.error(new GeneralException(
+                                            ErrorStatus.APPLE_AUTH_FAILED)))
                     )
                     .bodyToMono(AppleTokenResponseDTO.class)
                     .block();
 
             if (response == null || response.getAccessToken() == null) {
-                throw new RuntimeException("Apple Token 발급 실패: 응답 없음");
+                log.error("[Apple Token] 응답이 null이거나 accessToken이 없음");
+                throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
             }
 
             log.info("[Apple Token] 토큰 발급 성공");
             return response;
 
+        } catch (GeneralException e) {
+            throw e;
         } catch (Exception e) {
             log.error("[Apple Token] 토큰 발급 중 예외 발생", e);
-            throw new RuntimeException("Apple Token 발급 실패: " + e.getMessage(), e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
     }
 
@@ -200,20 +200,19 @@ public class AppleAuthService {
 
         } catch (Exception e) {
             log.error("[Apple Auth] Client Secret 생성 실패", e);
-            throw new RuntimeException("Apple Client Secret 생성 실패", e);
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
     }
 
     /**
      * Apple 회원탈퇴 처리
      * <p>
-     * 사용자 탈퇴 보장
+     * 탈퇴 보장:
      * - Apple 토큰 무효화는 best effort로 시도
      * - revoke 실패 시에도 사용자 삭제는 진행
      *
      * @param userId 사용자 ID
      */
-    @Transactional
     public void withdrawAppleUser(Long userId) {
         // 1. Apple Refresh Token 무효화 시도
         String appleRefreshToken = userAuthService.getAppleRefreshToken(userId);
@@ -224,7 +223,7 @@ public class AppleAuthService {
                 log.info("[Apple Withdraw] Apple 토큰 무효화 완료 - userId: {}", userId);
             } catch (Exception e) {
                 // Apple 서버 장애 등으로 실패해도 탈퇴는 진행
-                // 토큰은 60일 후 자동 만료, 사용자 데이터 삭제
+                // 토큰은 60일 후 자동 만료, 사용자 데이터 삭제 우선
                 log.error("[Apple Withdraw] Apple 토큰 무효화 실패 (사용자 탈퇴는 진행) - userId: {}, error: {}",
                         userId, e.getMessage(), e);
             }
@@ -232,7 +231,7 @@ public class AppleAuthService {
             log.warn("[Apple Withdraw] Apple Refresh Token 없음 - userId: {}", userId);
         }
 
-        // 2. 사용자 탈퇴 처리 (반드시 실행됨)
+        // 2. 사용자 탈퇴 처리 (항상 실행됨)
         userAuthService.withdrawUser(userId);
 
         log.info("[Apple Withdraw] 회원탈퇴 완료 - userId: {}", userId);

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -9,6 +9,7 @@ import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,16 +21,14 @@ import java.security.PrivateKey;
 
 /**
  * Apple 로그인 처리 메인 서비스
- *
- * 앱스토어 출시를 위한 완성도 높은 구현:
+ * <p>
  * 1. providerId(sub) 기반 사용자 식별
  * 2. 이메일 제공 동의 없이도 처리 가능
- * 3. 로그아웃/회원탈퇴 지원
+ * 3. 회원탈퇴 지원
  * 4. Refresh Token 관리
  */
 @Slf4j
 @Service
-@RequiredArgsConstructor
 @Transactional
 public class AppleAuthService {
 
@@ -39,6 +38,20 @@ public class AppleAuthService {
     private final UserAuthService userAuthService;
     private final AppleAuthConfig appleAuthConfig;
 
+    public AppleAuthService(
+            @Qualifier("appleWebClient") WebClient webClient,
+            AppleKeyService appleKeyService,
+            AppleAuthQueryService appleAuthQueryService,
+            UserAuthService userAuthService,
+            AppleAuthConfig appleAuthConfig
+    ) {
+        this.webClient = webClient;
+        this.appleKeyService = appleKeyService;
+        this.appleAuthQueryService = appleAuthQueryService;
+        this.userAuthService = userAuthService;
+        this.appleAuthConfig = appleAuthConfig;
+    }
+
     private static final String APPLE_TOKEN_URL = "https://appleid.apple.com/auth/token";
     private static final String APPLE_REVOKE_URL = "https://appleid.apple.com/auth/revoke";
 
@@ -47,8 +60,8 @@ public class AppleAuthService {
      * providerId(sub)로 사용자를 식별하여 이메일 없이도 로그인 가능합니다.
      *
      * @param authorizationCode Apple Authorization Code
-     * @param identityToken Apple Identity Token (JWT)
-     * @param username 사용자 이름 (선택)
+     * @param identityToken     Apple Identity Token (JWT)
+     * @param username          사용자 이름 (선택)
      * @return 로그인 응답 (JWT 토큰 포함)
      */
     public LoginResponseDTO loginWithApple(String authorizationCode, String identityToken,

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthService.java
@@ -5,6 +5,8 @@ import com.umc.puppymode2.domain.user.auth.dto.AppleTokenResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import lombok.RequiredArgsConstructor;
@@ -69,10 +71,11 @@ public class AppleAuthService {
         // 1. Identity Token 검증 및 사용자 정보 추출
         Claims claims = appleAuthQueryService.verifyIdentityToken(identityToken);
         if (claims == null) {
-            throw new IllegalArgumentException("Invalid Apple Identity Token");
+            log.error("[Apple Login] Identity Token 검증 실패");
+            throw new GeneralException(ErrorStatus.APPLE_AUTH_FAILED);
         }
 
-        // 2. providerId(sub) 추출 - 이것이 Apple의 고유 사용자 식별자
+        // 2. providerId(sub) 추출 - Apple의 고유 사용자 식별자
         String providerId = claims.getSubject();
         String email = claims.get("email", String.class);
 
@@ -252,7 +255,8 @@ public class AppleAuthService {
                     .onStatus(status -> status.isError(), clientResponse ->
                             clientResponse.bodyToMono(String.class)
                                     .doOnNext(errorBody -> log.error("[Apple Revoke] 에러: {}", errorBody))
-                                    .then(Mono.empty())
+                                    .flatMap(errorBody -> Mono.error(new RuntimeException(
+                                            "Apple 토큰 무효화 실패: " + errorBody)))
                     )
                     .bodyToMono(Void.class)
                     .block();

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleKeyService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleKeyService.java
@@ -1,0 +1,54 @@
+package com.umc.puppymode2.domain.user.auth.service;
+
+import com.umc.puppymode2.domain.user.auth.config.AppleAuthConfig;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.security.KeyFactory;
+import java.security.PrivateKey;
+import java.security.spec.PKCS8EncodedKeySpec;
+import java.util.Base64;
+
+/**
+ * Apple 인증에 필요한 Private Key를 관리하는 서비스
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleKeyService {
+
+    private final AppleAuthConfig appleAuthConfig;
+    private PrivateKey cachedPrivateKey;
+
+    /**
+     * Private Key를 로드합니다.
+     * 최초 호출 시 캐싱하여 재사용합니다.
+     *
+     * @return PrivateKey 객체
+     */
+    public PrivateKey getPrivateKey() {
+        if (cachedPrivateKey != null) {
+            return cachedPrivateKey;
+        }
+
+        try {
+            String privateKeyString = appleAuthConfig.getPrivateKey();
+
+            // Base64로 인코딩된 키를 디코딩
+            byte[] keyBytes = Base64.getDecoder().decode(privateKeyString);
+
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
+            KeyFactory keyFactory = KeyFactory.getInstance("EC");
+            cachedPrivateKey = keyFactory.generatePrivate(keySpec);
+
+            log.info("[Apple Key Service] Private Key 로드 완료");
+            return cachedPrivateKey;
+
+        } catch (Exception e) {
+            log.error("[Apple Key Service] Private Key 로드 실패", e);
+            throw new RuntimeException("Failed to load Apple Private Key", e);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleKeyService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleKeyService.java
@@ -5,7 +5,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.io.ByteArrayInputStream;
 import java.security.KeyFactory;
 import java.security.PrivateKey;
 import java.security.spec.PKCS8EncodedKeySpec;
@@ -36,9 +35,16 @@ public class AppleKeyService {
         try {
             String privateKeyString = appleAuthConfig.getPrivateKey();
 
-            // Base64로 인코딩된 키를 디코딩
-            byte[] keyBytes = Base64.getDecoder().decode(privateKeyString);
+            // PEM 포맷 처리: 헤더/푸터 제거 및 개행 제거
+            String sanitizedKey = privateKeyString
+                    .replace("-----BEGIN PRIVATE KEY-----", "")
+                    .replace("-----END PRIVATE KEY-----", "")
+                    .replaceAll("\\s+", "");  // 모든 공백/개행 제거
 
+            // Base64 디코딩
+            byte[] keyBytes = Base64.getDecoder().decode(sanitizedKey);
+
+            // EC Private Key 생성
             PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(keyBytes);
             KeyFactory keyFactory = KeyFactory.getInstance("EC");
             cachedPrivateKey = keyFactory.generatePrivate(keySpec);

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/ApplePublicKeyUtil.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/ApplePublicKeyUtil.java
@@ -1,0 +1,44 @@
+package com.umc.puppymode2.domain.user.auth.service;
+
+import com.umc.puppymode2.domain.user.auth.dto.ApplePublicKeysDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.PublicKey;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+
+/**
+ * Apple Identity Token 검증을 위한 공개키 유틸리티
+ */
+@Slf4j
+@Component
+public class ApplePublicKeyUtil {
+
+    /**
+     * Apple의 공개키 정보를 사용하여 PublicKey 객체를 생성합니다.
+     *
+     * @param key Apple 공개키 정보
+     * @return PublicKey 객체
+     */
+    public PublicKey generatePublicKey(ApplePublicKeysDTO.Key key) {
+        try {
+            byte[] nBytes = Base64.getUrlDecoder().decode(key.getN());
+            byte[] eBytes = Base64.getUrlDecoder().decode(key.getE());
+
+            BigInteger n = new BigInteger(1, nBytes);
+            BigInteger e = new BigInteger(1, eBytes);
+
+            RSAPublicKeySpec publicKeySpec = new RSAPublicKeySpec(n, e);
+            KeyFactory keyFactory = KeyFactory.getInstance("RSA");
+
+            return keyFactory.generatePublic(publicKeySpec);
+
+        } catch (Exception ex) {
+            log.error("[Apple Public Key] 공개키 생성 실패", ex);
+            throw new RuntimeException("Failed to generate Apple public key", ex);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
@@ -10,4 +10,14 @@ public interface UserAuthService {
 
     // 새로운 회윈 생성 또는 갱신
     LoginResponseDTO createOrUpdateUser(UserAuthInfoDTO userInfo, Provider authProvider, String refreshToken);
+
+    /**
+     * Apple Refresh Token을 조회합니다. (회원탈퇴 시 사용)
+     */
+    String getAppleRefreshToken(Long userId);
+
+    /**
+     * 회원탈퇴 처리를 합니다.
+     */
+    void withdrawUser(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -44,8 +44,8 @@ public class UserAuthServiceImpl implements UserAuthService {
         String email = userInfo.getEmail();
         String newUsername = userInfo.getUsername();
 
-        // TODO: providerId로 조회하여 중복 가입 방지 로직 추가 findByProviderIdAndProvider
-        Optional<SocialAuth> optionalUserAuth = socialAuthRepository.findByUser_EmailAndProvider(email, provider);
+        // providerId로 기존 사용자 조회 (중복 가입 방지)
+        Optional<SocialAuth> optionalUserAuth = socialAuthRepository.findByProviderIdAndProvider(providerId, provider);
 
         SocialAuth socialAuth;
         User user;
@@ -119,6 +119,19 @@ public class UserAuthServiceImpl implements UserAuthService {
     }
 
     /**
+     * Apple Refresh Token을 조회합니다.
+     * 로그아웃 및 회원탈퇴 시 Apple에 토큰 무효화 요청을 위해 사용됩니다.
+     *
+     * @param userId 사용자 ID
+     * @return Apple Refresh Token (없으면 null)
+     */
+    @Override
+    public String getAppleRefreshToken(Long userId) {
+        Optional<SocialAuth> socialAuth = socialAuthRepository.findByUserUserIdAndProvider(userId, Provider.APPLE);
+        return socialAuth.map(SocialAuth::getRefreshToken).orElse(null);
+    }
+
+    /**
      * 인증 객체를 설정합니다.
      *
      * @param user
@@ -168,5 +181,27 @@ public class UserAuthServiceImpl implements UserAuthService {
                 .expiresIn(expiresIn)
                 .userInfo(loginUserInfo)
                 .build();
+    }
+
+    /**
+     * 회원탈퇴 처리
+     * User 엔티티의 withdraw() 메서드를 호출하여 처리합니다.
+     *
+     * @param userId 사용자 ID
+     */
+    @Override
+    @Transactional
+    public void withdrawUser(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        // User 엔티티의 withdraw() 메서드 호출
+        // - 상태를 STOP으로 변경
+        // - 개인정보 마스킹 (이메일, 이름)
+        // - 연관 데이터 CASCADE 삭제 (socialAuths, drinkHistories, advices, puppy)
+        user.withdraw();
+
+        userRepository.save(user);
+        log.info("[Withdraw] 회원탈퇴 처리 완료 - userId: {}", userId);
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/repository/SocialAuthRepository.java
@@ -14,6 +14,12 @@ public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
 
     Optional<SocialAuth> findByUser_EmailAndProvider(String email, Provider provider);
 
+    /**
+     * providerId와 Provider로 SocialAuth를 조회합니다.
+     * Apple/Kakao 로그인 시 중복 가입 방지를 위해 사용됩니다.
+     */
+    Optional<SocialAuth> findByProviderIdAndProvider(String providerId, Provider provider);
+
     @Query("SELECT sa.refreshToken FROM SocialAuth sa WHERE sa.user.userId = :userId")
     Optional<String> findRefreshTokenByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -41,7 +41,6 @@ public enum ErrorStatus implements BaseErrorCode {
     // Apple 로그인 관련 에러
     APPLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요."),
     APPLE_MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "APPLE4002", "필수 입력값이 누락되었습니다."),
-    APPLE_WITHDRAW_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE5001", "회원탈퇴 처리 중 오류가 발생했습니다."),
 
     // Redis 관련 에러
     REDIS_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "REDIS5031", "Redis 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."),

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -38,6 +38,11 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH4001", "유효하지 않은 Refresh Token입니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "인증 정보가 유효하지 않습니다."),
 
+    // Apple 로그인 관련 에러
+    APPLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요."),
+    APPLE_MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "APPLE4002", "필수 입력값이 누락되었습니다."),
+    APPLE_WITHDRAW_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE5001", "회원탈퇴 처리 중 오류가 발생했습니다."),
+
     // Redis 관련 에러
     REDIS_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "REDIS5031", "Redis 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."),
     ;

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -15,6 +15,7 @@ public enum SuccessStatus implements BaseCode {
 
     // 인증 관련 응답
     AUTH_KAKAO_LOGIN_SUCCESS(HttpStatus.OK, "AUTH_KAKAO_200", "카카오 로그인 성공"),
+    AUTH_APPLE_LOGIN_SUCCESS(HttpStatus.OK, "AUTH_APPLE_200", "애플 로그인 성공"),
     AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH_REISSUE_200", "토큰 재발급 성공"),
     AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_LOGOUT_200", "로그아웃 성공"),
 
@@ -26,7 +27,7 @@ public enum SuccessStatus implements BaseCode {
 
     // 캘린더 조회
     CALENDAR_GET_SUCCESS(HttpStatus.OK, "CALENDAR200", "캘린더 조회 성공"),
-    
+
     // 한마디 조회
     ADVICE_GET_SUCCESS(HttpStatus.OK, "ADVICE200", "한마디 조회 성공");
 

--- a/src/main/java/com/umc/puppymode2/global/config/WebClientConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/WebClientConfig.java
@@ -24,4 +24,11 @@ public class WebClientConfig {
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .build();
     }
+
+    @Bean("appleWebClient")
+    public WebClient appleWebClient() {
+        return WebClient.builder()
+                .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_FORM_URLENCODED_VALUE)
+                .build();
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
 management:
   health:
     redis:
-      enabled: false  # Graceful Degradation을 위해 비활성화
+      enabled: false
 
 auth:
   jwt:
@@ -41,5 +41,5 @@ auth:
     team-id: ${APPLE_TEAM_ID}
     client-id: ${APPLE_CLIENT_ID}
     key-id: ${APPLE_KEY_ID}
-    private-key: ${APPLE_PRIVATE_KEY_BASE64}
+    private-key: ${APPLE_PRIVATE_KEY}
     redirect-uri: "https://puppy-mode.site/auth/apple/callback"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,3 +37,9 @@ auth:
   kakao:
     rest-api-key: ${KAKAO_REST_API_KEY}
     redirect-uri: http://localhost:8080/auth/kakao/login/callback
+  apple:
+    team-id: ${APPLE_TEAM_ID}
+    client-id: ${APPLE_CLIENT_ID}
+    key-id: ${APPLE_KEY_ID}
+    private-key: ${APPLE_PRIVATE_KEY_BASE64}
+    redirect-uri: "https://puppy-mode.site/auth/apple/callback"


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
애플 로그인/탈퇴 mvp 구현
로컬 테스트가 불가능 합니다

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#97

## 🔍 작업 내용  
- 애플 로그인을 통한 회원가입
- 애플 회원 탈퇴 (정보 삭제)

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple 로그인 및 Apple 계정 연동 탈퇴 기능 추가
  * Apple OAuth 설정(팀/클라이언트/키/리다이렉트) 등록 및 검증

* **API / 인증**
  * 애플 로그인 엔드포인트(로그인·웹 콜백·탈퇴) 제공
  * 애플 ID 토큰 검증, 공개키 처리, 클라이언트 시크릿 생성, 토큰 발급·폐기 흐름 지원
  * 관련 요청/응답 DTO 추가

* **Error Handling**
  * Apple 관련 성공·오류 상태 코드 및 메시지 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->