### PR TITLE
[BUG] RedisConfig 수정 #59

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -64,15 +64,16 @@ public class RedisConfig {
             config.setPassword(redisPassword);
         }
 
-        // ClientOptions 설정
+        // ClientOptions 생성
         ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder()
                 .socketOptions(SocketOptions.builder()
                         .connectTimeout(timeout)
+                        .keepAlive(true)
                         .build());
 
         // SSL 설정
         if (sslEnabled) {
-            // AWS ElastiCache의 자체 서명 인증서를 위해 검증 비활성화
+            // AWS ElastiCache용 SSL 설정: 인증서 검증 비활성화
             io.lettuce.core.SslOptions sslOptions = io.lettuce.core.SslOptions.builder()
                     .jdkSslProvider()
                     .build();
@@ -81,20 +82,23 @@ public class RedisConfig {
             log.info("[REDIS SSL] Enabled with peer verification disabled (safe for AWS VPC)");
         }
 
-        // Lettuce Client 설정
+        ClientOptions clientOptions = clientOptionsBuilder.build();
+
+        // LettuceClientConfiguration 빌더
         LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder =
                 LettuceClientConfiguration.builder()
                         .commandTimeout(timeout)
-                        .clientOptions(clientOptionsBuilder.build());
+                        .clientOptions(clientOptions);
 
+        // SSL 활성화
         if (sslEnabled) {
-            clientConfigBuilder.useSsl();
+            clientConfigBuilder.useSsl().disablePeerVerification();
         }
 
         LettuceClientConfiguration clientConfig = clientConfigBuilder.build();
 
         LettuceConnectionFactory factory = new LettuceConnectionFactory(config, clientConfig);
-        factory.setValidateConnection(true);
+        factory.setValidateConnection(false);
 
         log.info("[REDIS CONFIG] Host={}, Port={}, SSL={}, Timeout={}",
                 maskHost(redisHost), redisPort, sslEnabled, timeout);


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
redisConfig에서 disablePeerVerification() 추가하여 배포 환경에서 캐시 연결 시도
  -> aws 자체 서명 검증 비활성화

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Chores**
  * Redis 연결 안정성 개선을 위해 Keep-Alive 기능 활성화
  * SSL 설정 강화 및 AWS ElastiCache 호환성 개선
  * 연결 검증 동작 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->