### PR TITLE
[BUG] RedisConfig 수정 #59

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,7 @@ dependencies {
 
     // redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'io.lettuce.core:lettuce-core'
 
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 }

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -65,24 +65,12 @@ public class RedisConfig {
         }
 
         // ClientOptions 생성
-        ClientOptions.Builder clientOptionsBuilder = ClientOptions.builder()
+        ClientOptions clientOptions = ClientOptions.builder()
                 .socketOptions(SocketOptions.builder()
                         .connectTimeout(timeout)
                         .keepAlive(true)
-                        .build());
-
-        // SSL 설정
-        if (sslEnabled) {
-            // AWS ElastiCache용 SSL 설정: 인증서 검증 비활성화
-            io.lettuce.core.SslOptions sslOptions = io.lettuce.core.SslOptions.builder()
-                    .jdkSslProvider()
-                    .build();
-
-            clientOptionsBuilder.sslOptions(sslOptions);
-            log.info("[REDIS SSL] Enabled with peer verification disabled (safe for AWS VPC)");
-        }
-
-        ClientOptions clientOptions = clientOptionsBuilder.build();
+                        .build())
+                .build();
 
         // LettuceClientConfiguration 빌더
         LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder =
@@ -92,12 +80,15 @@ public class RedisConfig {
 
         // SSL 활성화
         if (sslEnabled) {
-            clientConfigBuilder.useSsl().disablePeerVerification();
+            clientConfigBuilder
+                    .useSsl()
+                    .disablePeerVerification();
+            log.info("[REDIS SSL] TLS enabled (AWS ElastiCache compatible)");
         }
 
-        LettuceClientConfiguration clientConfig = clientConfigBuilder.build();
+        LettuceConnectionFactory factory =
+                new LettuceConnectionFactory(config, clientConfigBuilder.build());
 
-        LettuceConnectionFactory factory = new LettuceConnectionFactory(config, clientConfig);
         factory.setValidateConnection(false);
 
         log.info("[REDIS CONFIG] Host={}, Port={}, SSL={}, Timeout={}",

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -78,12 +78,15 @@ public class RedisConfig {
                         .commandTimeout(timeout)
                         .clientOptions(clientOptions);
 
-        // SSL 활성화
+        // SSL 활성화 (AWS ElastiCache용)
         if (sslEnabled) {
+            // disablePeerVerification(): AWS ElastiCache TLS 연결에 필요
+            // - Amazon Root CA가 Docker/ECS 기본 신뢰 저장소에 없을 수 있음
+            // - VPC 내부 통신이므로 보안상 안전 (보안그룹으로 접근 제어, TLS 암호화 유지)
             clientConfigBuilder
                     .useSsl()
                     .disablePeerVerification();
-            log.info("[REDIS SSL] TLS enabled (AWS ElastiCache compatible)");
+            log.info("[REDIS SSL] TLS enabled with peer verification disabled (safe for AWS VPC)");
         }
 
         LettuceConnectionFactory factory =

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -81,8 +81,6 @@ public class RedisConfig {
         // SSL 활성화 (AWS ElastiCache용)
         if (sslEnabled) {
             // disablePeerVerification(): AWS ElastiCache TLS 연결에 필요
-            // - Amazon Root CA가 Docker/ECS 기본 신뢰 저장소에 없을 수 있음
-            // - VPC 내부 통신이므로 보안상 안전 (보안그룹으로 접근 제어, TLS 암호화 유지)
             clientConfigBuilder
                     .useSsl()
                     .disablePeerVerification();


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
SslOptions.builder().jdkSslProvider() 삭제 하여 내부 충돌 해결

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
#59

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Redis 클라이언트의 SSL/TLS 처리 흐름을 정리하고 연결 구성 과정을 간소화했으며, 검증 비활성화 옵션을 명확히 적용했습니다. 관련 로그 문구도 사용자 관점에서 이해하기 쉽게 갱신되었습니다.
* **Chores**
  * 빌드에 Redis 클라이언트 의존성이 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->