### PR TITLE
[FEAT] 카카오 로그인 예외 추가 #117

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
@@ -16,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/KakaoAuthController.java
@@ -16,6 +16,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -96,7 +97,17 @@ public class KakaoAuthController {
     )
     @ApiErrorCodeExamples({
             ErrorStatus._BAD_REQUEST,
-            ErrorStatus.AUTH_INVALID_TOKEN
+            ErrorStatus.AUTH_INVALID_TOKEN,
+            ErrorStatus.KAKAO_TOKEN_INVALID,
+            ErrorStatus.KAKAO_RATE_LIMITED,
+            ErrorStatus.KAKAO_SERVER_ERROR,
+            ErrorStatus.KAKAO_API_ERROR,
+            ErrorStatus.KAKAO_TOKEN_REFRESH_FAILED,
+            ErrorStatus.KAKAO_USER_INFO_INVALID,
+            ErrorStatus.KAKAO_FORBIDDEN,
+            ErrorStatus.KAKAO_BAD_REQUEST,
+            ErrorStatus.KAKAO_SERVICE_UNAVAILABLE,
+            ErrorStatus.KAKAO_TIMEOUT
     })
     public ResponseEntity<ApiResponse<LoginResponseDTO>> kakaoLogin(
             @Valid @RequestBody KakaoLoginRequestDTO request

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -139,7 +139,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private void setAuthentication(User user) {
         Authentication authentication = new UserAuthentication(user.getUserId(), null, null);
         SecurityContextHolder.getContext().setAuthentication(authentication);
-        log.info("[AUTH] SecurityContext에 인증 객체 설정 완료 - userId={}", user.getUserId());
+        log.debug("[AUTH] SecurityContext에 인증 객체 설정 완료 - userId={}", user.getUserId());
     }
 
     /**
@@ -161,13 +161,13 @@ public class UserAuthServiceImpl implements UserAuthService {
             jwtTokenService.saveRefreshToken(userId, refreshToken);
             log.info("[LOGIN] Refresh Token 발급 및 저장 완료 - userId={}", userId);
         } else {
-            log.warn("[LOGIN] Redis 미사용 가능 - Refresh Token 없이 로그인 처리 - userId={}", userId);
+            log.debug("[LOGIN] Redis 미사용 가능 - Refresh Token 없이 로그인 처리 - userId={}", userId);
         }
 
         Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
 
 
-        log.info("[LOGIN] 토큰 발급 완료 - userId={}", userId);
+        log.debug("[LOGIN] 토큰 발급 완료 - userId={}", userId);
 
         LoginResponseDTO.LoginUserInfo loginUserInfo = LoginResponseDTO.LoginUserInfo.builder()
                 .userId(user.getUserId())

--- a/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
@@ -1,11 +1,12 @@
 package com.umc.puppymode2.domain.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.umc.puppymode2.domain.user.auth.dto.KakaoTokenResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.KakaoUserInfoResponseDTO;
 import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
 import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -13,7 +14,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.ClientResponse;
 import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @Slf4j
 @Service
@@ -29,37 +37,18 @@ public class KakaoAuthService {
     @Qualifier("kakaoTokenWebClient")
     private final WebClient kakaoTokenWebClient;
 
-
     @Value("${auth.kakao.rest-api-key}")
     private String kakaoRestApiKey;
 
     /**
      * 카카오 회원의 정보를 가져옵니다.
      *
-     * @param accessToken
-     * @return 회원 정보 전체
+     * @param accessToken 카카오 액세스 토큰
+     * @return 회원 정보
+     * @throws GeneralException 카카오 API 호출 실패 시
      */
     public UserAuthInfoDTO getUserInfo(String accessToken) {
-        KakaoUserInfoResponseDTO userInfo = kakaoWebClient.get()
-                .uri("/v2/user/me")
-                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, response ->
-                        response.bodyToMono(String.class).map(errorBody -> {
-                            log.error("[Kakao Service] API 에러 응답: {}", errorBody);
-                            handleKakaoApiError(errorBody);
-                            return new RuntimeException("카카오 API 실패");
-                        })
-                )
-                .bodyToMono(KakaoUserInfoResponseDTO.class)
-                .block();
-
-//        log.debug("[Kakao Service] raw 응답: {}", toJson(userInfo));
-
-//        log.debug("[ Kakao Service ] Auth ID —> {} ", userInfo.getId());
-//        log.debug("[ Kakao Service ] NickName —> {} ", userInfo.getKakaoAccount().getProfile().getNickName());
-//        log.debug("[ Kakao Service ] email —> {} ", userInfo.getKakaoAccount().getEmail());
-
+        KakaoUserInfoResponseDTO userInfo = fetchKakaoUserInfo(accessToken);
         validateKakaoUserInfo(userInfo);
 
         return UserAuthInfoDTO.builder()
@@ -71,93 +60,19 @@ public class KakaoAuthService {
 
     /**
      * refreshToken을 사용하여 새로운 accessToken을 발급합니다.
+     *
+     * @param userId 사용자 ID
+     * @return 새로운 액세스 토큰
+     * @throws GeneralException refresh token이 없거나 갱신 실패 시
      */
     public String refreshAccessToken(Long userId) {
-        String refreshToken = socialAuthRepository.findRefreshTokenByUserId(userId)
-                .orElseThrow(() -> new RuntimeException("Refresh token not found"));
+        String refreshToken = getRefreshTokenFromDB(userId);
+        KakaoTokenResponseDTO tokenResponse = requestNewAccessToken(refreshToken);
 
-        KakaoTokenResponseDTO tokenResponse = kakaoTokenWebClient.post()
-                .uri(uriBuilder -> uriBuilder
-                        .path("/oauth/token")
-                        .queryParam("grant_type", "refresh_token")
-                        .queryParam("client_id", kakaoRestApiKey)
-                        .queryParam("refresh_token", refreshToken)
-                        .build())
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, response ->
-                        response.bodyToMono(String.class).map(errorBody -> {
-                            log.error("[Kakao Service] API 에러 응답: {}", errorBody);
-                            handleKakaoApiError(errorBody);
-                            return new RuntimeException("카카오 API 실패");
-                        })
-                )
-                .bodyToMono(KakaoTokenResponseDTO.class)
-                .block();
-        log.debug("[Kakao Service] raw 응답: {}", toJson(tokenResponse));
-
-        if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
-            throw new RuntimeException("Failed to refresh Kakao access token");
-        }
-
-        if (tokenResponse.getRefreshToken() != null) {
-            updateRefreshTokenInDB(userId, tokenResponse.getRefreshToken());
-        }
+        validateTokenResponse(tokenResponse);
+        updateRefreshTokenIfPresent(userId, tokenResponse.getRefreshToken());
 
         return tokenResponse.getAccessToken();
-    }
-
-    /**
-     * user_auth 테이블의 refreshToken을 업데이트합니다.
-     */
-    private void updateRefreshTokenInDB(Long userId, String newRefreshToken) {
-        socialAuthRepository.updateRefreshToken(userId, newRefreshToken);
-        log.debug("[Kakao Service] Refresh token updated");
-    }
-
-    /**
-     * 카카오 사용자 정보가 null 인지 검사합니다.
-     */
-    private void validateKakaoUserInfo(KakaoUserInfoResponseDTO userInfo) {
-        if (userInfo == null || userInfo.getId() == null) {
-            throw new IllegalArgumentException("카카오 계정의 고유 ID(auth_id)가 존재하지 않습니다.");
-        }
-
-        if (userInfo.getKakaoAccount() == null) {
-            throw new IllegalArgumentException("카카오 계정 정보가 존재하지 않습니다.");
-        }
-
-        if (userInfo.getKakaoAccount().getProfile() == null ||
-                userInfo.getKakaoAccount().getProfile().getNickName() == null) {
-            throw new IllegalArgumentException("카카오 닉네임 정보가 존재하지 않습니다.");
-        }
-
-        if (userInfo.getKakaoAccount().getEmail() == null) {
-            throw new IllegalArgumentException("카카오 이메일 정보가 존재하지 않습니다.");
-        }
-    }
-
-    /**
-     * 예외 처리
-     */
-    private void handleKakaoApiError(String errorResponse) {
-        if (errorResponse.contains("\"code\": -401")) {
-            throw new IllegalArgumentException("잘못된 Access Token입니다. 재로그인이 필요합니다.");
-        }
-        if (errorResponse.contains("\"code\": -402")) {
-            throw new IllegalStateException("카카오 API 사용량 초과. 잠시 후 다시 시도하세요.");
-        }
-        if (errorResponse.contains("\"code\": -500")) {
-            throw new RuntimeException("카카오 서버 내부 오류 발생. 나중에 다시 시도해주세요.");
-        }
-        throw new RuntimeException("카카오 API 요청 실패: " + errorResponse);
-    }
-
-    private String toJson(Object obj) {
-        try {
-            return objectMapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            return "[json 변환 실패]";
-        }
     }
 
     /**
@@ -184,5 +99,174 @@ public class KakaoAuthService {
             log.error("[Kakao disconnect] 카카오 계정 연결 해제 중 예외 발생", e);
             return false;
         }
+    }
+
+    // ==================== Private Methods ====================
+
+    /**
+     * 카카오 API를 통해 사용자 정보를 조회합니다.
+     */
+    private KakaoUserInfoResponseDTO fetchKakaoUserInfo(String accessToken) {
+        KakaoUserInfoResponseDTO userInfo = kakaoWebClient.get()
+                .uri("/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError,
+                        response -> handleKakaoError(response, "GET_USER_INFO"))
+                .bodyToMono(KakaoUserInfoResponseDTO.class)
+                .block();
+
+        if (userInfo == null) {
+            log.error("[Kakao Service] GET_USER_INFO - 응답이 null");
+            throw new GeneralException(ErrorStatus.KAKAO_API_ERROR);
+        }
+
+        log.debug("[Kakao Service] GET_USER_INFO 성공 - userId: {}", userInfo.getId());
+        return userInfo;
+    }
+
+    /**
+     * DB에서 refresh token을 조회합니다.
+     */
+    private String getRefreshTokenFromDB(Long userId) {
+        return socialAuthRepository.findRefreshTokenByUserId(userId)
+                .orElseThrow(() -> {
+                    log.error("[Kakao Service] Refresh token not found - userId: {}", userId);
+                    return new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+                });
+    }
+
+    /**
+     * 카카오 API를 통해 새로운 액세스 토큰을 요청합니다.
+     */
+    private KakaoTokenResponseDTO requestNewAccessToken(String refreshToken) {
+        KakaoTokenResponseDTO tokenResponse = kakaoTokenWebClient.post()
+                .uri(uriBuilder -> uriBuilder
+                        .path("/oauth/token")
+                        .queryParam("grant_type", "refresh_token")
+                        .queryParam("client_id", kakaoRestApiKey)
+                        .queryParam("refresh_token", refreshToken)
+                        .build())
+                .retrieve()
+                .onStatus(HttpStatusCode::isError,
+                        response -> handleKakaoError(response, "REFRESH_TOKEN"))
+                .bodyToMono(KakaoTokenResponseDTO.class)
+                .block();
+
+        log.debug("[Kakao Service] REFRESH_TOKEN API 호출 완료");
+        return tokenResponse;
+    }
+
+    /**
+     * 토큰 응답의 유효성을 검증합니다.
+     */
+    private void validateTokenResponse(KakaoTokenResponseDTO tokenResponse) {
+        if (tokenResponse == null || tokenResponse.getAccessToken() == null) {
+            log.error("[Kakao Service] REFRESH_TOKEN 실패 - 응답 null 또는 access_token 없음");
+            throw new GeneralException(ErrorStatus.KAKAO_TOKEN_REFRESH_FAILED);
+        }
+    }
+
+    /**
+     * 새로운 refresh token이 있으면 DB에 업데이트합니다.
+     */
+    private void updateRefreshTokenIfPresent(Long userId, String newRefreshToken) {
+        Optional.ofNullable(newRefreshToken).ifPresent(token -> {
+            socialAuthRepository.updateRefreshToken(userId, token);
+            log.debug("[Kakao Service] Refresh token 업데이트 완료 - userId: {}", userId);
+        });
+    }
+
+    /**
+     * 카카오 사용자 정보의 필수 필드를 검증합니다.
+     *
+     * @throws GeneralException 필수 정보가 없을 경우
+     */
+    private void validateKakaoUserInfo(KakaoUserInfoResponseDTO userInfo) {
+        if (userInfo.getId() == null) {
+            log.error("[Kakao Service] 카카오 고유 ID(auth_id) null");
+            throw new GeneralException(ErrorStatus.KAKAO_USER_INFO_INVALID);
+        }
+
+        if (userInfo.getKakaoAccount() == null) {
+            log.error("[Kakao Service] 카카오 계정 정보 null");
+            throw new GeneralException(ErrorStatus.KAKAO_USER_INFO_INVALID);
+        }
+
+        if (userInfo.getKakaoAccount().getProfile() == null ||
+                userInfo.getKakaoAccount().getProfile().getNickName() == null) {
+            log.error("[Kakao Service] 카카오 닉네임 정보 null");
+            throw new GeneralException(ErrorStatus.KAKAO_USER_INFO_INVALID);
+        }
+
+        if (userInfo.getKakaoAccount().getEmail() == null) {
+            log.error("[Kakao Service] 카카오 이메일 정보 null");
+            throw new GeneralException(ErrorStatus.KAKAO_USER_INFO_INVALID);
+        }
+    }
+
+    /**
+     * WebClient 에러 응답을 처리하고 적절한 예외로 변환합니다.
+     */
+    private Mono<? extends Throwable> handleKakaoError(ClientResponse response, String operation) {
+        return response.bodyToMono(String.class)
+                .defaultIfEmpty("")
+                .flatMap(errorBody -> {
+                    log.error("[Kakao Service] {} 실패 - status: {}", operation, response.statusCode());
+                    log.debug("[Kakao Service] {} 에러 상세: {}", operation, sanitize(errorBody));
+
+                    return Mono.error(mapKakaoError(errorBody));
+                });
+    }
+
+    /**
+     * 카카오 에러 코드를 애플리케이션 예외로 매핑합니다.
+     */
+    private static final Set<Integer> BAD_REQUEST_CODES =
+            Set.of(-2, -201, -101, -102, -103, -501, -602, -606, -911);
+
+    private static final Set<Integer> FORBIDDEN_CODES =
+            Set.of(-3, -402);
+
+    private static final Pattern KAKAO_CODE_PATTERN =
+            Pattern.compile("\"code\"\\s*:\\s*(-?\\d+)");
+
+    private GeneralException mapKakaoError(String errorBody) {
+        int code = extractCode(errorBody);
+
+        if (code == -401 || code == -903) return new GeneralException(ErrorStatus.KAKAO_TOKEN_INVALID);
+        if (BAD_REQUEST_CODES.contains(code)) return new GeneralException(ErrorStatus.KAKAO_BAD_REQUEST);
+        if (FORBIDDEN_CODES.contains(code)) return new GeneralException(ErrorStatus.KAKAO_FORBIDDEN);
+        if (code == -603) return new GeneralException(ErrorStatus.KAKAO_TIMEOUT);
+        if (code == -9798) return new GeneralException(ErrorStatus.KAKAO_SERVICE_UNAVAILABLE);
+
+        return new GeneralException(ErrorStatus.KAKAO_API_ERROR);
+    }
+
+    private int extractCode(String body) {
+        if (body == null || body.isBlank()) return 0;
+
+        Matcher m = KAKAO_CODE_PATTERN.matcher(body);
+        if (!m.find()) return 0;
+
+        try {
+            return Integer.parseInt(m.group(1));
+        } catch (NumberFormatException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * 민감한 정보(토큰 등)를 마스킹 처리합니다.
+     */
+    private String sanitize(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return raw;
+        }
+
+        return raw
+                .replaceAll("\"access_token\"\\s*:\\s*\"[^\"]+\"", "\"access_token\":\"***\"")
+                .replaceAll("\"refresh_token\"\\s*:\\s*\"[^\"]+\"", "\"refresh_token\":\"***\"")
+                .replaceAll("\"id_token\"\\s*:\\s*\"[^\"]+\"", "\"id_token\":\"***\"");
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/KakaoAuthService.java
@@ -239,6 +239,7 @@ public class KakaoAuthService {
         if (FORBIDDEN_CODES.contains(code)) return new GeneralException(ErrorStatus.KAKAO_FORBIDDEN);
         if (code == -603) return new GeneralException(ErrorStatus.KAKAO_TIMEOUT);
         if (code == -9798) return new GeneralException(ErrorStatus.KAKAO_SERVICE_UNAVAILABLE);
+        if (code == -10) return new GeneralException(ErrorStatus.KAKAO_RATE_LIMITED);
 
         return new GeneralException(ErrorStatus.KAKAO_API_ERROR);
     }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -38,6 +38,18 @@ public enum ErrorStatus implements BaseErrorCode {
     AUTH_REFRESH_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "AUTH4001", "유효하지 않은 Refresh Token입니다."),
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4002", "인증 정보가 유효하지 않습니다."),
 
+    // Kakao 로그인 관련 에러
+    KAKAO_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "KAKAO4001", "카카오 인증 정보가 유효하지 않습니다. 다시 로그인해주세요."),
+    KAKAO_RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "KAKAO4002", "카카오 인증 요청이 많습니다. 잠시 후 다시 시도해주세요."),
+    KAKAO_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO4003", "카카오 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    KAKAO_API_ERROR(HttpStatus.BAD_GATEWAY, "KAKAO4004", "카카오 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."),
+    KAKAO_TOKEN_REFRESH_FAILED(HttpStatus.UNAUTHORIZED, "KAKAO4005", "카카오 인증 갱신에 실패했습니다. 다시 로그인해주세요."),
+    KAKAO_USER_INFO_INVALID(HttpStatus.BAD_REQUEST, "KAKAO4006", "카카오 사용자 정보가 올바르지 않습니다. 카카오 계정 설정을 확인해주세요."),
+    KAKAO_FORBIDDEN(HttpStatus.FORBIDDEN, "KAKAO4007", "카카오 권한/설정이 부족합니다. 동의 항목 및 앱 설정을 확인해주세요."),
+    KAKAO_BAD_REQUEST(HttpStatus.BAD_REQUEST, "KAKAO4008", "카카오 요청 값이 올바르지 않습니다."),
+    KAKAO_SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "KAKAO4009", "카카오 서비스 점검 중입니다. 잠시 후 다시 시도해주세요."),
+    KAKAO_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "KAKAO4010", "카카오 요청 처리 중 시간이 초과되었습니다. 잠시 후 다시 시도해주세요."),
+
     // Apple 로그인 관련 에러
     APPLE_AUTH_FAILED(HttpStatus.UNAUTHORIZED, "APPLE4001", "애플 로그인에 실패했습니다. 다시 시도해주세요."),
     APPLE_MISSING_REQUIRED_FIELD(HttpStatus.BAD_REQUEST, "APPLE4002", "필수 입력값이 누락되었습니다."),


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
카카오 로그인 에러 매핑을 추가했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #117

## 🔍 작업 내용  
- errorstatus 추가
- kakao service 예외 발생 시 원인 명확화

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 카카오 계정 연결 해제(언링크) 기능 추가

* **Bug Fixes**
  * 카카오 연동 에러 처리 개선 및 토큰 갱신(리프레시) 워크플로우 보강
  * 카카오 관련 상세 오류(10종) 메시지 추가로 문제 원인 명확화

* **Chores**
  * 내부 로깅 레벨 조정(일부 메시지 디버그화)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->