### PR TITLE
[BUG] 애플 로그인 검증값 수정 #121

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/config/AppleAuthConfig.java
@@ -21,8 +21,7 @@ import java.util.List;
 public class AppleAuthConfig {
 
     private String teamId;
-    private String clientId;
-    private String audience;
+    private String clientId; // App Bundle ID
     private String keyId;
     private List<String> privateKeyLines;
     private String redirectUri;
@@ -38,8 +37,7 @@ public class AppleAuthConfig {
 
         log.info("[Apple Config] Apple 인증 설정 검증 완료");
         log.info("[Apple Config] - Team ID: {}", maskString(teamId));
-        log.info("[Apple Config] - Client(Service) ID: {}", maskString(clientId));
-        log.info("[Apple Config] - Audience(App) ID: {}", maskString(audience));
+        log.info("[Apple Config] - Client(Bundle) ID: {}", maskString(clientId));
         log.info("[Apple Config] - Key ID: {}", maskString(keyId));
         log.info("[Apple Config] - Private Key Lines: {} 줄",
                 privateKeyLines != null ? privateKeyLines.size() : 0);
@@ -55,10 +53,6 @@ public class AppleAuthConfig {
 
         if (isBlank(clientId)) {
             throw new IllegalStateException("Apple Client ID가 설정되지 않았습니다. auth.apple.client-id를 확인하세요.");
-        }
-
-        if (isBlank(audience)) {
-            throw new IllegalStateException("Apple Audience가 설정되지 않았습니다. auth.apple.audience를 확인하세요.");
         }
 
         if (isBlank(keyId)) {

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/AppleAuthQueryService.java
@@ -78,7 +78,7 @@ public class AppleAuthQueryService {
             Claims claims = Jwts.parserBuilder()
                     .setSigningKey(publicKey)
                     .requireIssuer("https://appleid.apple.com")
-                    .requireAudience(appleAuthConfig.getAudience())
+                    .requireAudience(appleAuthConfig.getClientId())
                     .build()
                     .parseClaimsJws(identityToken)
                     .getBody();


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
애플 로그인 검증 값 web버전 -> 앱 버전으로 완전히 수정

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #121

## 🔍 작업 내용  
- client id = bundle id로 모두 통일
- audience 값 삭제

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **버그 수정**
  * Apple 인증 설정을 간소화했습니다. 불필요한 필드를 제거하고 인증 토큰 검증 로직을 개선했습니다.

* **개선사항**
  * Apple 인증 구성 시 필수 입력값이 단순화되어 설정 과정이 더욱 편리해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->