### PR TITLE
[BUG] 온보딩 테스트 강아지 유형비율 조정 #132

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/service/OnboardingTestService.java
@@ -46,16 +46,9 @@ public class OnboardingTestService {
             int a = answer.answer();
 
             switch (q) {
-                case 1, 2 -> { // E or I
+                case 1, 2, 5 -> { // E or I
                     if (a == 1) eScore++;
                     else iScore++;
-                }
-                case 5 -> { // E/F or I/T
-                    if (a == 1) {
-                        eScore++; fScore++;
-                    } else {
-                        iScore++; tScore++;
-                    }
                 }
                 case 3, 4, 6 -> { // F or T
                     if (a == 1) fScore++;
@@ -66,8 +59,8 @@ public class OnboardingTestService {
         }
 
         // 두 유형 중 어느쪽에 해당하는지 판별 후 강아지 종 매칭
-        String eOrI = (eScore >= iScore) ? "E" : "I";
-        String fOrT = (fScore >= tScore) ? "F" : "T";
+        String eOrI = (eScore > iScore) ? "E" : "I";
+        String fOrT = (fScore > tScore) ? "F" : "T";
         PuppyType type = getDogTypeByTrait(eOrI, fOrT);
 
         // 해당 강아지 타입의 Level 1 찾기


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
- 온보딩에서 강아지 유형 테스트 진행 시, 강아지 4종 중 2종만 나옴(비숑, 푸들만 나옴)
    -> 특정 질문에서 E/I와 T/F를 모두 결정하고 있는 바람에, EF / IT 쪽으로 강하게 결합되어 결과가 치중된 것으로 판단
    -> 해당 질문을 E/I만 판단하도록 수정하여, 강아지 유형 분포가 각 25%씩이 되도록 변경

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #132 

## 🔍 작업 내용  
- 작업 내용 1  
- 작업 내용 2  
- 작업 내용 3

## ✅ 체크리스트  
- [ ] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선사항**
  * 성격 유형 검사의 점수 산정 로직이 조정되었습니다.
  * 특정 문항의 점수 처리 방식이 통합되어 평가 일관성이 개선되었습니다.
  * 동점 상황에서의 결과 판정 방식이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->