### PR TITLE
[BUG] 목표 31개 설정 시 400 에러 #130

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/controller/UserGoalHistoryController.java
@@ -50,14 +50,14 @@ public class UserGoalHistoryController {
         );
     }
 
-    // 3. 목표 설정 후 30일 경과 여부
+    // 3. 이번 달 목표 설정 여부
     @GetMapping("/check-30days")
-    @Operation(summary = "목표 설정 후 30일 경과 여부 API", description = "목표 설정 후 30일 경과 여부 API 입니다.")
+    @Operation(summary = "이번 달 목표 설정 여부 API", description = "이번 달 목표가 설정되어 있는지 확인합니다.")
     public ResponseEntity<ApiResponse<Boolean>> check30Days() {
         Long userId = getCurrentUserId();
         boolean isPassed = queryService.isMoreThan30DayPassed(userId);
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(isPassed, "GOAL200", "목표 설정 후 30일 경과 여부 조회 성공")
+                ApiResponse.onSuccess(isPassed, "GOAL200", "이번 달 목표 설정 여부 조회 성공")
         );
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
@@ -3,7 +3,6 @@ package com.umc.puppymode2.domain.goal.converter;
 import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
 import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
@@ -12,17 +11,18 @@ import java.time.LocalDateTime;
 @Component
 public class UserGoalHistoryConverter {
 
-    public UserGoalHistory toEntity(GoalPostRequestDTO dto, Long userId) {
-
-        int goal = dto.getGoal();
-        LocalDate now = LocalDate.now();
-        LocalDate goalMonth = now.withDayOfMonth(1);
+    public UserGoalHistory toEntity(
+            GoalPostRequestDTO dto,
+            Long userId,
+            LocalDate goalMonth,
+            LocalDateTime goalSetAt
+    ) {
 
         return UserGoalHistory.builder()
                 .userId(userId)
                 .goalMonth(goalMonth)
-                .monthlyGoalCount(goal)
-                .goalSetAt(LocalDateTime.now())
+                .monthlyGoalCount(dto.getGoal())
+                .goalSetAt(goalSetAt)
                 .build();
     }
 

--- a/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
@@ -28,7 +28,7 @@ public class UserGoalHistoryConverter {
 
     public GoalInfoResponseDTO toDto(UserGoalHistory entity, Long monthlyActualCount) {
 
-        boolean exceeded = monthlyActualCount > entity.getMonthlyGoalCount();
+        boolean exceeded = monthlyActualCount >= entity.getMonthlyGoalCount();
 
         return GoalInfoResponseDTO.builder()
                 .monthlyGoalCount(entity.getMonthlyGoalCount())

--- a/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/converter/UserGoalHistoryConverter.java
@@ -6,33 +6,34 @@ import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Component
-@RequiredArgsConstructor
 public class UserGoalHistoryConverter {
 
-    public UserGoalHistory toEntity(GoalPostRequestDTO dto, Long userId, Long monthlyActualCount) {
+    public UserGoalHistory toEntity(GoalPostRequestDTO dto, Long userId) {
 
-        if (dto.getGoal() == null) {
-            throw new IllegalArgumentException("목표 값은 null일 수 없습니다.");
-        }
+        int goal = dto.getGoal();
+        LocalDate now = LocalDate.now();
+        LocalDate goalMonth = now.withDayOfMonth(1);
 
         return UserGoalHistory.builder()
                 .userId(userId)
-                .monthlyGoalCount(dto.getGoal())
-                .monthlyActualCount(monthlyActualCount)
-                .isGoalExceeded(false)
+                .goalMonth(goalMonth)
+                .monthlyGoalCount(goal)
                 .goalSetAt(LocalDateTime.now())
                 .build();
     }
 
-
     public GoalInfoResponseDTO toDto(UserGoalHistory entity, Long monthlyActualCount) {
+
+        boolean exceeded = monthlyActualCount > entity.getMonthlyGoalCount();
+
         return GoalInfoResponseDTO.builder()
                 .monthlyGoalCount(entity.getMonthlyGoalCount())
                 .monthlyActualCount(monthlyActualCount)
-                .isGoalExceeded(entity.getIsGoalExceeded())
+                .isGoalExceeded(exceeded)
                 .goalSetAt(entity.getGoalSetAt())
                 .build();
     }

--- a/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
@@ -5,37 +5,62 @@ import lombok.*;
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_goal_history")
+@Table(
+        name = "user_goal_history",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        // 한 유저는 한 달에 목표 하나만 생성 가능
+                        name = "uk_user_goal_month",
+                        columnNames = {"user_id", "goal_month"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_user_goal_user", columnList = "user_id")
+        }
+)
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 public class UserGoalHistory {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "goal_id")
     private Long goalId;
 
+    // FK 컬럼 명확히 지정
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
-    private Integer monthlyGoalCount;  // 이번 달 목표 음주 횟수
+    // 목표가 적용되는 월 (항상 해당 월의 1일 저장)
+    @Column(name = "goal_month", nullable = false)
+    private LocalDate goalMonth;
 
-    private Long monthlyActualCount; // 이번 달 실제 음주 횟수
+    // 이번 달 목표 음주 횟수
+    @Column(name = "monthly_goal_count", nullable = false)
+    private Integer monthlyGoalCount;
 
-    private Boolean isGoalExceeded;
-
+    // 목표 설정 시간
+    @Column(name = "goal_set_at", nullable = false)
     private LocalDateTime goalSetAt;
 
+    // 마지막 GPT 코멘트 전송 시간
+    @Column(name = "last_gpt_comment_sent_at")
     private LocalDateTime lastGptCommentSentAt;
 
+    // 생성 시간
     @CreationTimestamp
-    @Column(updatable = false)
+    @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
 
+    // 수정 시간
     @UpdateTimestamp
+    @Column(name = "updated_at")
     private LocalDateTime updatedAt;
-
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.time.LocalDate;
 
 @Repository
 public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory, Long> {
@@ -15,6 +16,16 @@ public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory
     Optional<UserGoalHistory> findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(
             Long userId, LocalDateTime asOfDate
     );
+
+    // 특정 월 목표 조회
+    Optional<UserGoalHistory> findByUserIdAndGoalMonth(Long userId, LocalDate goalMonth);
+
+    // 특정 월 목표 존재 여부 확인 (중복 요청 방지)
+    boolean existsByUserIdAndGoalMonth(Long userId, LocalDate goalMonth);
+
+    // 가장 최근 목표 조회 (기존 목표 유지 기능)
+    Optional<UserGoalHistory> findTopByUserIdOrderByGoalMonthDesc(Long userId);
+
 
     @Modifying
     @Query("DELETE FROM UserGoalHistory ugh WHERE ugh.userId = :userId")

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
@@ -24,63 +25,66 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
     public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
 
         LocalDate now = LocalDate.now();
-        LocalDate goalMonth = now.withDayOfMonth(1); // 이번 달을 식별하는 기준 날짜
+        LocalDate goalMonth = now.withDayOfMonth(1);
         int maxGoal = now.lengthOfMonth();
 
-        // 새로운 목표 설정
-        if (Boolean.TRUE.equals(dto.getIsNew())) {
+        try {
 
-            if (dto.getGoal() == null) {
-                throw new IllegalArgumentException("새로운 목표 설정 시 goal 값은 필수입니다.");
+            // 새로운 목표 설정
+            if (Boolean.TRUE.equals(dto.getIsNew())) {
+
+                if (dto.getGoal() == null) {
+                    throw new IllegalArgumentException("새로운 목표 설정 시 goal 값은 필수입니다.");
+                }
+
+                if (dto.getGoal() <= 0 || dto.getGoal() > maxGoal) {
+                    throw new IllegalArgumentException("목표는 1 이상 " + maxGoal + " 이하여야 합니다.");
+                }
+
+                if (repository.existsByUserIdAndGoalMonth(userId, goalMonth)) {
+                    throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
+                }
+
+                UserGoalHistory newGoal = converter.toEntity(dto, userId);
+
+                repository.save(newGoal);
+
+                return GoalPostResponseDTO.builder()
+                        .isSuccess(true)
+                        .code("POST_GOAL_SUCCESS")
+                        .message("목표 설정 성공")
+                        .build();
             }
 
-            if (dto.getGoal() <= 0 || dto.getGoal() > maxGoal) {
-                throw new IllegalArgumentException("목표는 1 이상 " + maxGoal + " 이하여야 합니다.");
-            }
+            // 기존 목표 유지
+            UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalMonthDesc(userId)
+                    .orElseThrow(() -> new IllegalArgumentException("기존 목표가 없습니다."));
 
-            // 이미 이번 달 목표가 있는지 먼저 체크
             if (repository.existsByUserIdAndGoalMonth(userId, goalMonth)) {
                 throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
             }
 
-            // Entity 생성
-            UserGoalHistory newGoal = converter.toEntity(dto, userId);
+            int adjustedGoal = Math.min(lastGoal.getMonthlyGoalCount(), maxGoal);
 
-            repository.save(newGoal);
+            UserGoalHistory copiedGoal = UserGoalHistory.builder()
+                    .userId(userId)
+                    .goalMonth(goalMonth)
+                    .monthlyGoalCount(adjustedGoal)
+                    .goalSetAt(LocalDateTime.now())
+                    .build();
+
+            repository.save(copiedGoal);
 
             return GoalPostResponseDTO.builder()
                     .isSuccess(true)
-                    .code("POST_GOAL_SUCCESS")
-                    .message("목표 설정 성공")
+                    .code("MAINTAIN_GOAL_SUCCESS")
+                    .message("기존 목표 유지 성공")
                     .build();
-        }
 
-        // 기존 목표 유지
-        // 가장 최근 목표를 가져와서 이번 달 목표로 복사
-        UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalMonthDesc(userId)
-                .orElseThrow(() -> new IllegalArgumentException("기존 목표가 없습니다."));
+        } catch (DataIntegrityViolationException e) {
 
-        // 이미 이번 달 목표가 있는지 체크
-        if (repository.existsByUserIdAndGoalMonth(userId, goalMonth)) {
+            // DB UNIQUE(user_id, goal_month) 제약 위반
             throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
         }
-
-        // 이전 목표가 이번 달 최대 일수보다 크면 보정
-        int adjustedGoal = Math.min(lastGoal.getMonthlyGoalCount(), now.lengthOfMonth());
-
-        UserGoalHistory copiedGoal = UserGoalHistory.builder()
-                .userId(userId)
-                .goalMonth(goalMonth)
-                .monthlyGoalCount(adjustedGoal)
-                .goalSetAt(LocalDateTime.now())
-                .build();
-
-        repository.save(copiedGoal);
-
-        return GoalPostResponseDTO.builder()
-                .isSuccess(true)
-                .code("MAINTAIN_GOAL_SUCCESS")
-                .message("기존 목표 유지 성공")
-                .build();
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -1,6 +1,5 @@
 package com.umc.puppymode2.domain.goal.service;
 
-import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
 import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
@@ -16,34 +15,37 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommandService {
+
     private final UserGoalHistoryRepository repository;
     private final UserGoalHistoryConverter converter;
-    private final DrinkHistoryRepository drinkHistoryRepository;
-
-    private static final int MAX_GOAL = 31;
 
     @Transactional
     @Override
     public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
 
         LocalDate now = LocalDate.now();
-        LocalDate firstDayOfMonth = now.withDayOfMonth(1);
-        LocalDate lastDayOfMonth = now.withDayOfMonth(now.lengthOfMonth());
+        LocalDate goalMonth = now.withDayOfMonth(1); // 이번 달을 식별하는 기준 날짜
+        int maxGoal = now.lengthOfMonth();
 
-        Long actualDrinkCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDayOfMonth, lastDayOfMonth);
-
+        // 새로운 목표 설정
         if (Boolean.TRUE.equals(dto.getIsNew())) {
 
             if (dto.getGoal() == null) {
                 throw new IllegalArgumentException("새로운 목표 설정 시 goal 값은 필수입니다.");
             }
 
-            // 기준 : 오늘부터 30일의 목표
-            if (dto.getGoal() < 0 || dto.getGoal() > MAX_GOAL) {
-                throw new IllegalArgumentException("목표는 0 이상 " + MAX_GOAL + " 이하여야 합니다.");
+            if (dto.getGoal() <= 0 || dto.getGoal() > maxGoal) {
+                throw new IllegalArgumentException("목표는 1 이상 " + maxGoal + " 이하여야 합니다.");
             }
 
-            UserGoalHistory newGoal = converter.toEntity(dto, userId, actualDrinkCount);
+            // 이미 이번 달 목표가 있는지 먼저 체크
+            if (repository.existsByUserIdAndGoalMonth(userId, goalMonth)) {
+                throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
+            }
+
+            // Entity 생성
+            UserGoalHistory newGoal = converter.toEntity(dto, userId);
+
             repository.save(newGoal);
 
             return GoalPostResponseDTO.builder()
@@ -51,28 +53,31 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
                     .code("POST_GOAL_SUCCESS")
                     .message("목표 설정 성공")
                     .build();
-        } else {
-            // 기존 목표 유지
-            UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
-                    .orElseThrow(() -> new IllegalArgumentException("기존 목표가 없습니다."));
-            UserGoalHistory copiedGoal = UserGoalHistory.builder()
-                    .userId(userId)
-                    .monthlyGoalCount(lastGoal.getMonthlyGoalCount())
-                    .monthlyActualCount(actualDrinkCount)
-                    .isGoalExceeded(false)
-                    .goalSetAt(LocalDateTime.now())
-                    .createdAt(LocalDateTime.now())
-                    .updatedAt(LocalDateTime.now())
-                    .build();
-
-            repository.save(copiedGoal);
-
-            return GoalPostResponseDTO.builder()
-                    .isSuccess(true)
-                    .code("MAINTAIN_GOAL_SUCCESS")
-                    .message("기존 목표 유지 성공")
-                    .build();
         }
+
+        // 기존 목표 유지
+        // 가장 최근 목표를 가져와서 이번 달 목표로 복사
+        UserGoalHistory lastGoal = repository.findTopByUserIdOrderByGoalMonthDesc(userId)
+                .orElseThrow(() -> new IllegalArgumentException("기존 목표가 없습니다."));
+
+        // 이미 이번 달 목표가 있는지 체크
+        if (repository.existsByUserIdAndGoalMonth(userId, goalMonth)) {
+            throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
+        }
+
+        UserGoalHistory copiedGoal = UserGoalHistory.builder()
+                .userId(userId)
+                .goalMonth(goalMonth)
+                .monthlyGoalCount(lastGoal.getMonthlyGoalCount())
+                .goalSetAt(LocalDateTime.now())
+                .build();
+
+        repository.save(copiedGoal);
+
+        return GoalPostResponseDTO.builder()
+                .isSuccess(true)
+                .code("MAINTAIN_GOAL_SUCCESS")
+                .message("기존 목표 유지 성공")
+                .build();
     }
 }
-

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -26,6 +26,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
 
         LocalDate now = LocalDate.now();
         LocalDate goalMonth = now.withDayOfMonth(1);
+        LocalDateTime goalSetAt = LocalDateTime.now();
         int maxGoal = now.lengthOfMonth();
 
         try {
@@ -45,7 +46,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
                     throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
                 }
 
-                UserGoalHistory newGoal = converter.toEntity(dto, userId);
+                UserGoalHistory newGoal = converter.toEntity(dto, userId, goalMonth, goalSetAt);
 
                 repository.save(newGoal);
 
@@ -70,7 +71,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
                     .userId(userId)
                     .goalMonth(goalMonth)
                     .monthlyGoalCount(adjustedGoal)
-                    .goalSetAt(LocalDateTime.now())
+                    .goalSetAt(goalSetAt)
                     .build();
 
             repository.save(copiedGoal);

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -65,10 +65,13 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
             throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
         }
 
+        // 이전 목표가 이번 달 최대 일수보다 크면 보정
+        int adjustedGoal = Math.min(lastGoal.getMonthlyGoalCount(), now.lengthOfMonth());
+
         UserGoalHistory copiedGoal = UserGoalHistory.builder()
                 .userId(userId)
                 .goalMonth(goalMonth)
-                .monthlyGoalCount(lastGoal.getMonthlyGoalCount())
+                .monthlyGoalCount(adjustedGoal)
                 .goalSetAt(LocalDateTime.now())
                 .build();
 

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -20,6 +20,8 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
     private final UserGoalHistoryConverter converter;
     private final DrinkHistoryRepository drinkHistoryRepository;
 
+    private static final int MAX_GOAL = 31;
+
     @Transactional
     @Override
     public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
@@ -35,8 +37,10 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
             if (dto.getGoal() == null) {
                 throw new IllegalArgumentException("새로운 목표 설정 시 goal 값은 필수입니다.");
             }
-            if (dto.getGoal() < 0 || dto.getGoal() > 30) {
-                throw new IllegalArgumentException("목표는 0 이상 30 이하여야 합니다.");
+
+            // 기준 : 오늘부터 30일의 목표
+            if (dto.getGoal() < 0 || dto.getGoal() > MAX_GOAL) {
+                throw new IllegalArgumentException("목표는 0 이상 " + MAX_GOAL + " 이하여야 합니다.");
             }
 
             UserGoalHistory newGoal = converter.toEntity(dto, userId, actualDrinkCount);

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
@@ -48,7 +49,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
 
                 UserGoalHistory newGoal = converter.toEntity(dto, userId, goalMonth, goalSetAt);
 
-                repository.save(newGoal);
+                repository.saveAndFlush(newGoal);
 
                 return GoalPostResponseDTO.builder()
                         .isSuccess(true)
@@ -74,7 +75,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
                     .goalSetAt(goalSetAt)
                     .build();
 
-            repository.save(copiedGoal);
+            repository.saveAndFlush(copiedGoal);
 
             return GoalPostResponseDTO.builder()
                     .isSuccess(true)
@@ -85,7 +86,18 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
         } catch (DataIntegrityViolationException e) {
 
             // DB UNIQUE(user_id, goal_month) 제약 위반
-            throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
+            Throwable cause = e;
+
+            while (cause != null) {
+                if (cause instanceof ConstraintViolationException constraintException) {
+                    if ("uk_user_goal_month".equals(constraintException.getConstraintName())) {
+                        throw new IllegalStateException("이미 이번 달 목표가 설정되어 있습니다.");
+                    }
+                }
+                cause = cause.getCause();
+            }
+
+            throw e;
         }
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
@@ -9,36 +9,46 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 @Service
 @RequiredArgsConstructor
 public class UserGoalHistoryQueryServiceImpl implements UserGoalHistoryQueryService {
+
     private final UserGoalHistoryRepository repository;
     private final UserGoalHistoryConverter converter;
     private final DrinkHistoryRepository drinkHistoryRepository;
 
-
     @Override
     public GoalInfoResponseDTO getLatestGoal(Long userId) {
-        UserGoalHistory latest = repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
+
+        LocalDate now = LocalDate.now();
+        LocalDate goalMonth = now.withDayOfMonth(1); // 이번 달 기준
+
+        // 이번 달 목표 조회
+        UserGoalHistory goal = repository
+                .findByUserIdAndGoalMonth(userId, goalMonth)
                 .orElse(null);
 
-        if (latest == null) return null;
+        if (goal == null) return null;
 
-        LocalDate firstDay = LocalDate.now().withDayOfMonth(1);
-        LocalDate lastDay = LocalDate.now().withDayOfMonth(LocalDate.now().lengthOfMonth());
-        long actualCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDay, lastDay);
+        // 이번 달 음주 횟수 계산
+        LocalDate firstDay = goalMonth;
+        LocalDate lastDay = goalMonth.withDayOfMonth(goalMonth.lengthOfMonth());
 
-        return converter.toDto(latest, actualCount);
+        long actualCount =
+                drinkHistoryRepository.countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(
+                        userId, firstDay, lastDay
+                );
+
+        return converter.toDto(goal, actualCount);
     }
 
     @Override
     public boolean isMoreThan30DayPassed(Long userId) {
-        return repository.findTopByUserIdOrderByGoalSetAtDesc(userId)
-                .map(goal -> ChronoUnit.DAYS.between(goal.getGoalSetAt(), LocalDateTime.now()) >= 30)
-                .orElse(true);
 
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        // 이번 달 목표 존재 여부 확인
+        return repository.findByUserIdAndGoalMonth(userId, goalMonth).isEmpty();
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
@@ -52,7 +52,7 @@ class UserGoalHistoryCommandServiceImplTest {
         var result = service.postGoal(userId, dto);
 
         assertTrue(result.isSuccess());
-        verify(repository).save(entity);
+        verify(repository).saveAndFlush(entity);
     }
 
     @Test
@@ -93,7 +93,7 @@ class UserGoalHistoryCommandServiceImplTest {
         assertThrows(IllegalStateException.class,
                 () -> service.postGoal(userId, dto));
 
-        verify(repository, never()).save(any());
+        verify(repository, never()).saveAndFlush(any());
     }
 
     @Test
@@ -116,7 +116,7 @@ class UserGoalHistoryCommandServiceImplTest {
         var result = service.postGoal(userId, dto);
 
         assertTrue(result.isSuccess());
-        verify(repository).save(any());
+        verify(repository).saveAndFlush(any());
     }
 
     @Test
@@ -150,7 +150,7 @@ class UserGoalHistoryCommandServiceImplTest {
 
         service.postGoal(userId, dto);
 
-        verify(repository).save(argThat(goal ->
+        verify(repository).saveAndFlush(argThat(goal ->
                 goal.getMonthlyGoalCount() ==
                         Math.min(31, LocalDate.now().lengthOfMonth())
         ));

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
@@ -46,7 +46,7 @@ class UserGoalHistoryCommandServiceImplTest {
         when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
                 .thenReturn(false);
 
-        when(converter.toEntity(dto, userId))
+        when(converter.toEntity(eq(dto), eq(userId), any(LocalDate.class), any(LocalDateTime.class)))
                 .thenReturn(entity);
 
         var result = service.postGoal(userId, dto);

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
@@ -1,0 +1,158 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
+import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserGoalHistoryCommandServiceImplTest {
+
+    @Mock
+    private UserGoalHistoryRepository repository;
+
+    @Mock
+    private UserGoalHistoryConverter converter;
+
+    @InjectMocks
+    private UserGoalHistoryCommandServiceImpl service;
+
+    private final Long userId = 1L;
+
+    @Test
+    void 새로운_목표_설정_성공() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(true, 5);
+
+        UserGoalHistory entity = UserGoalHistory.builder()
+                .userId(userId)
+                .monthlyGoalCount(5)
+                .goalMonth(LocalDate.of(2025,3,1))
+                .goalSetAt(LocalDateTime.now())
+                .build();
+
+        when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
+                .thenReturn(false);
+
+        when(converter.toEntity(dto, userId))
+                .thenReturn(entity);
+
+        var result = service.postGoal(userId, dto);
+
+        assertTrue(result.isSuccess());
+        verify(repository).save(entity);
+    }
+
+    @Test
+    void 목표_null이면_예외() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(true, null);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.postGoal(userId, dto));
+    }
+
+    @Test
+    void 목표값이_0이면_예외() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(true, 0);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.postGoal(userId, dto));
+    }
+
+    @Test
+    void 목표값_범위_초과() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(true, 50);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.postGoal(userId, dto));
+    }
+
+    @Test
+    void 이미_목표가_존재하면_예외() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(true, 5);
+
+        when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
+                .thenReturn(true);
+
+        assertThrows(IllegalStateException.class,
+                () -> service.postGoal(userId, dto));
+
+        verify(repository, never()).save(any());
+    }
+
+    @Test
+    void 기존_목표_유지_성공() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(false, null);
+
+        UserGoalHistory lastGoal = UserGoalHistory.builder()
+                .monthlyGoalCount(3)
+                .goalMonth(LocalDate.of(2025,2,1))
+                .goalSetAt(LocalDateTime.now())
+                .build();
+
+        when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
+                .thenReturn(false);
+
+        when(repository.findTopByUserIdOrderByGoalMonthDesc(userId))
+                .thenReturn(Optional.of(lastGoal));
+
+        var result = service.postGoal(userId, dto);
+
+        assertTrue(result.isSuccess());
+        verify(repository).save(any());
+    }
+
+    @Test
+    void 기존_목표가_없으면_예외() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(false, null);
+
+        when(repository.findTopByUserIdOrderByGoalMonthDesc(userId))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalArgumentException.class,
+                () -> service.postGoal(userId, dto));
+    }
+
+    @Test
+    void 기존_목표가_이번달_최대일수를_초과하면_보정된다() {
+
+        GoalPostRequestDTO dto = new GoalPostRequestDTO(false, null);
+
+        UserGoalHistory lastGoal = UserGoalHistory.builder()
+                .monthlyGoalCount(31)
+                .goalMonth(LocalDate.of(2025,1,1))
+                .goalSetAt(LocalDateTime.now())
+                .build();
+
+        when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
+                .thenReturn(false);
+
+        when(repository.findTopByUserIdOrderByGoalMonthDesc(userId))
+                .thenReturn(Optional.of(lastGoal));
+
+        service.postGoal(userId, dto);
+
+        verify(repository).save(argThat(goal ->
+                goal.getMonthlyGoalCount() ==
+                        Math.min(31, LocalDate.now().lengthOfMonth())
+        ));
+    }
+}

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
@@ -136,7 +136,7 @@ class UserGoalHistoryQueryServiceImplTest {
     }
 
     @Test
-    void 목표와_실제_음주가_같으면_goalExceeded_false() {
+    void 목표와_실제_음주가_같으면_goalExceeded_true() {
 
         LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
 
@@ -158,6 +158,6 @@ class UserGoalHistoryQueryServiceImplTest {
 
         var result = service.getLatestGoal(userId);
 
-        assertFalse(result.getIsGoalExceeded());
+        assertTrue(result.getIsGoalExceeded());
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
@@ -1,0 +1,163 @@
+package com.umc.puppymode2.domain.goal.service;
+
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
+import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserGoalHistoryQueryServiceImplTest {
+
+    @Mock
+    private UserGoalHistoryRepository repository;
+
+    @Mock
+    private UserGoalHistoryConverter converter;
+
+    @Mock
+    private DrinkHistoryRepository drinkHistoryRepository;
+
+    @InjectMocks
+    private UserGoalHistoryQueryServiceImpl service;
+
+    private final Long userId = 1L;
+
+    @Test
+    void 목표_조회_성공() {
+
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        UserGoalHistory goal = UserGoalHistory.builder()
+                .userId(userId)
+                .goalMonth(goalMonth)
+                .monthlyGoalCount(5)
+                .goalSetAt(LocalDateTime.now())
+                .build();
+
+        GoalInfoResponseDTO dto = GoalInfoResponseDTO.builder()
+                .monthlyGoalCount(5)
+                .monthlyActualCount(2L)
+                .isGoalExceeded(false)
+                .build();
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.of(goal));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(anyLong(), any(), any()))
+                .thenReturn(2L);
+
+        when(converter.toDto(goal, 2L))
+                .thenReturn(dto);
+
+        var result = service.getLatestGoal(userId);
+
+        assertNotNull(result);
+        assertEquals(5, result.getMonthlyGoalCount());
+        assertEquals(2, result.getMonthlyActualCount());
+    }
+
+    @Test
+    void 목표가_없으면_null() {
+
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.empty());
+
+        var result = service.getLatestGoal(userId);
+
+        assertNull(result);
+    }
+
+    @Test
+    void 이번달_목표_없으면_30일_지남_true() {
+
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.empty());
+
+        assertTrue(service.isMoreThan30DayPassed(userId));
+    }
+
+    @Test
+    void 이번달_목표_있으면_false() {
+
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        UserGoalHistory goal = UserGoalHistory.builder()
+                .goalMonth(goalMonth)
+                .build();
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.of(goal));
+
+        assertFalse(service.isMoreThan30DayPassed(userId));
+    }
+
+    @Test
+    void 목표보다_실제_음주가_많으면_goalExceeded_true() {
+
+        LocalDate goalMonth = LocalDate.of(2025,3,1);
+
+        UserGoalHistory goal = UserGoalHistory.builder()
+                .userId(userId)
+                .goalMonth(goalMonth)
+                .monthlyGoalCount(5)
+                .build();
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.of(goal));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(any(), any(), any()))
+                .thenReturn(6L);
+
+        when(converter.toDto(goal, 6L))
+                .thenCallRealMethod();
+
+        var result = service.getLatestGoal(userId);
+
+        assertTrue(result.getIsGoalExceeded());
+    }
+
+    @Test
+    void 목표와_실제_음주가_같으면_goalExceeded_false() {
+
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+
+        UserGoalHistory goal = UserGoalHistory.builder()
+                .userId(userId)
+                .goalMonth(goalMonth)
+                .monthlyGoalCount(5)
+                .build();
+
+        when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
+                .thenReturn(Optional.of(goal));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(any(), any(), any()))
+                .thenReturn(5L);
+
+        when(converter.toDto(goal, 5L))
+                .thenCallRealMethod();
+
+        var result = service.getLatestGoal(userId);
+
+        assertFalse(result.getIsGoalExceeded());
+    }
+}

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
@@ -112,7 +112,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 목표보다_실제_음주가_많으면_goalExceeded_true() {
 
-        LocalDate goalMonth = LocalDate.of(2025,3,1);
+        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
 
         UserGoalHistory goal = UserGoalHistory.builder()
                 .userId(userId)


### PR DESCRIPTION
# 🚀 PR 개요  
목표 관리 로직을 `goalSetAt` 기반에서 `goalMonth` 기반 월 단위 구조로 리팩토링하고, 

월 최대 일수에 맞게 목표 개수를 검증 및 보정하도록 개선했습니다.

## 🔗 관련 이슈  
Closes #130

## 🔍 작업 내용  

- 목표 관리 기준을 `goalSetAt` 기반 구조에서 `goalMonth` 기반 월 단위 구조로 변경  
- 한 달에 하나의 목표만 설정 가능하도록 `UNIQUE(user_id, goal_month)` 제약 적용  
- 목표 생성 로직을 월 기준으로 동작하도록 수정  
- 기존 목표 유지 시 이전 목표가 이번 달 일수보다 클 경우 월 최대 일수로 자동 보정하도록 로직 추가  
  - 예: 이전 목표 31 → 이번 달 30일 → 30으로 자동 보정  
  - 예: 이전 목표 31 → 2월(28일) → 28로 자동 보정  
- 목표 개수 검증 로직을 월 최대 일수 기준으로 개선  
  - LocalDate.now().lengthOfMonth() 활용  
- 목표 조회 시 DrinkHistory 데이터를 기반으로 월간 실제 음주 횟수 계산  
- Entity ↔ DTO 변환 로직을 Converter 계층으로 분리  
- 목표 생성 및 조회 관련 서비스 로직 정리 및 테스트 코드 추가  

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  

### 1️⃣ 목표 관리 구조 리팩토링

기존 목표 관리 로직은 `goalSetAt`(목표 설정 시간)을 기준으로 동작하고 있었으나,  
PM님과 논의 하에 기획상 목표는 **월 단위로 관리되는 것이 더 자연스러운 도메인 모델**이라고 판단하여  
`goalMonth` 기반 구조로 리팩토링했습니다.

이를 통해 다음과 같은 구조로 변경되었습니다.

- 목표 관리 기준  
  `goalSetAt` → `goalMonth`

- 한 유저는 한 달에 하나의 목표만 가질 수 있도록 설계

---

### 2️⃣ 기존 목표 유지 시 월 최대 일수 보정

기존 목표 유지 기능에서 이전 목표를 그대로 복사할 경우  
이번 달의 최대 일수보다 큰 목표가 저장될 수 있는 문제가 있었습니다.

예시

- 이전 목표 31 → 이번 달 30일 → 목표 31 (달성 불가능)
- 이전 목표 31 → 2월(28일) → 목표 31 (달성 불가능)

이를 방지하기 위해 다음과 같은 보정 로직을 추가했습니다.

```java
adjustedGoal = Math.min(lastGoalCount, now.lengthOfMonth())
```

예시

- 이전 목표 31 → 이번 달 30일 → 30
- 이전 목표 31 → 2월(28일) → 28

이를 통해 **월 단위 목표의 현실적인 달성 가능성을 보장하도록 개선했습니다.**

---

### 3️⃣ 동시성 처리 방식에 대한 기술적 고민

목표 생성 시 **사용자의 더블 클릭 또는 동시 요청으로 인해 동일한 달의 목표가 여러 번 생성될 가능성**이 존재합니다.

이를 해결하기 위해 다음 두 가지 방식 중 하나를 고려했습니다.

1️⃣ **Pessimistic Lock (비관적 락)**  
2️⃣ **DB UNIQUE Constraint**

---

### Pessimistic Lock 방식

장점

- 애플리케이션 레벨에서 동시성 제어 가능

단점

- 불필요한 DB 락으로 인해 성능 저하 가능
- 목표 생성은 쓰기 빈도가 높지 않은 작업
- 단순한 중복 방지 문제에 비해 구현이 과도할 수 있음

---

### UNIQUE Constraint 방식 ✅

다음과 같은 이유로 DB 레벨에서 해결하는 방식이 더 적절하다고 판단했습니다.

- 문제의 본질이 **데이터 무결성(한 달에 목표 하나)** 이기 때문
- DB constraint가 가장 확실한 방어 수단
- 애플리케이션 로직 복잡도 감소
- 락 기반 방식보다 성능 부담이 적음

따라서 다음과 같은 제약을 적용했습니다.

```java
UNIQUE(user_id, goal_month)
```

그리고 서비스 로직에서는

1️⃣ `existsByUserIdAndGoalMonth`로 사전 체크  
2️⃣ DB UNIQUE constraint로 최종 방어

**2단계 방어 구조**로 동시성 문제를 해결했습니다.

### 👇 인덱스 성능 최적화 테스트 문서
- [user_goal_history 조회 성능 개선을 위한 인덱스 최적화](https://www.notion.so/user_goal_history-31dcbf635507806cbe0bdbfeef466ca9?source=copy_link)

---

### 4️⃣ 기대 효과

이번 리팩토링을 통해

- 목표 관리 로직이 도메인 개념(월 단위)과 일치
- 월별 목표 데이터의 정합성 보장
- 동시 요청 상황에서도 목표 중복 생성 방지
- 목표 달성 가능성 보장 (월 일수 기반 보정)

하도록 개선되었습니다.

---

### 5️⃣ saveAndFlush를 통한 DB 제약 조건 즉시 검증

JPA의 `save()` 메서드는 내부적으로 **INSERT SQL 실행을 트랜잭션 flush 또는 commit 시점까지 지연할 수 있습니다.**

따라서 다음과 같은 코드에서는

```
repository.save(entity)
```

UNIQUE 제약 위반이 **서비스 메서드 내부에서 발생하지 않고 트랜잭션 commit 시점에 발생할 수 있습니다.**

이 경우 서비스 레이어에서 예외를 처리하려는 의도와 다르게  
예외가 상위 계층으로 그대로 전파될 수 있습니다.

이를 해결하기 위해 다음과 같이 `saveAndFlush()`를 사용했습니다.

```java
repository.saveAndFlush(entity)
```

`saveAndFlush()`는

1️⃣ 엔티티를 저장한 뒤  
2️⃣ 즉시 flush를 수행하여  
3️⃣ DB에 INSERT SQL을 바로 실행합니다.

이를 통해

- DB UNIQUE 제약 조건을 **서비스 로직 내에서 즉시 검증**
- `DataIntegrityViolationException`을 **서비스 계층에서 명확히 처리 가능**
- 예외 흐름을 의도한 방식으로 제어

할 수 있도록 개선했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 목표 추적을 월별로 전환하여 이번 달 기준으로 목표를 관리
  * 같은 달 중복 목표 등록 방지 및 입력값(1~해당 월 일수) 검증 추가
  * 기존 목표 유지 시 이번 달 길이에 맞춰 목표 자동 조정 및 데이터 무결성 강화
* **문서/메시지**
  * API 응답 및 설명 문구를 “이번 달 목표 설정 여부”로 업데이트
* **테스트**
  * 관련 서비스 동작을 검증하는 단위 테스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->