### PR TITLE
[BUG] 음주 리포트 달성률 이상 + 캘린더 불일치 #131

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -18,6 +18,7 @@ import java.time.YearMonth;
 @Service
 @RequiredArgsConstructor
 public class DrinkReportServiceImpl implements DrinkReportService {
+
     private final UserGoalHistoryRepository userGoalHistoryRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final AdviceRepository adviceRepository;
@@ -27,34 +28,62 @@ public class DrinkReportServiceImpl implements DrinkReportService {
     @Override
     public DrinkReportResponseDTO drinkReport(Long userId, YearMonth targetMonth) {
 
-        LocalDate firstDayOfMonth = targetMonth.atDay(1);
-        LocalDate lastDayOfMonth = targetMonth.atEndOfMonth();
+        LocalDate startDate = targetMonth.atDay(1);
+        LocalDate endDate = targetMonth.atEndOfMonth();
 
-        LocalDateTime startDateTime = firstDayOfMonth.atStartOfDay();
-        LocalDateTime asOfDateTime = lastDayOfMonth.atTime(LocalTime.MAX);
+        LocalDateTime startDateTime = startDate.atStartOfDay();
+        LocalDateTime endDateTime = endDate.atTime(LocalTime.MAX);
 
         int goal = userGoalHistoryRepository
-                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(userId, asOfDateTime)
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(userId, endDateTime)
                 .map(UserGoalHistory::getMonthlyGoalCount)
-                .orElse(15); // 기본값 15
+                .orElse(15);
 
-        long drinkRecordCount = drinkHistoryRepository.countByUserUserIdAndDrinkDateBetween(userId, firstDayOfMonth, lastDayOfMonth);
+        // 술을 정말 마신 날 (isDrink = True)
+        long drinkDays = drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(
+                        userId,
+                        startDate,
+                        endDate
+                );
+        // 사용자의 해당 월 기록 횟수 (true, false 모두)
+        long drinkRecordCount = drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(
+                        userId,
+                        startDate,
+                        endDate
+                );
 
-        long drinkDays = drinkHistoryRepository.countDistinctDrinkDates(userId, firstDayOfMonth, lastDayOfMonth);
-
-        // 절주 목표 유지율! (마신 비율이 아니라, 목표대비 안마신 비율!) 최대한 안마시는게 목표
-        int achievementRate;
-        if (goal <= 0 || drinkDays >= goal) {
-            achievementRate = 0;
-        } else {
-            achievementRate = (int) (((double) (goal - drinkDays) / goal) * 100);
-        }
+        int achievementRate = calculateAchievementRate(goal, drinkDays);
 
         int scoldedCount = (int) adviceRepository
-                .countByUserUserIdAndAdvisedAtBetween(userId, startDateTime, asOfDateTime);
+                .countByUserUserIdAndAdvisedAtBetween(
+                        userId,
+                        startDateTime,
+                        endDateTime
+                );
 
-        DrinkReportResponseDTO dto = drinkReportConverter.toDto(goal, Long.valueOf(drinkRecordCount), Long.valueOf(drinkDays), achievementRate, scoldedCount);
+        return drinkReportConverter.toDto(
+                goal,
+                drinkRecordCount,
+                drinkDays,
+                achievementRate,
+                scoldedCount
+        );
+    }
 
-        return dto;
+    /**
+     * 절주 목표 달성률 계산
+     * 목표 대비 실제 음주일이 얼마나 적은지 계산
+     */
+    private int calculateAchievementRate(int goal, long drinkDays) {
+
+        if (goal <= 0) {
+            return 0;
+        }
+
+        double rate = ((double) (goal - drinkDays) / goal) * 100;
+
+        return (int) Math.max(rate, 0);
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
@@ -1,0 +1,297 @@
+package com.umc.puppymode2.domain.report.service;
+
+import com.umc.puppymode2.domain.advice.repository.AdviceRepository;
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.util.Optional;
+
+import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+class DrinkReportServiceImplTest {
+
+    @Mock
+    private UserGoalHistoryRepository userGoalHistoryRepository;
+
+    @Mock
+    private DrinkHistoryRepository drinkHistoryRepository;
+
+    @Mock
+    private AdviceRepository adviceRepository;
+
+    @Mock
+    private DrinkReportConverter drinkReportConverter;
+
+    @InjectMocks
+    private DrinkReportServiceImpl drinkReportService;
+
+    private Long userId;
+    private YearMonth targetMonth;
+
+    @BeforeEach
+    void setUp() {
+        userId = 1L;
+        targetMonth = YearMonth.of(2024, 3);
+    }
+
+    @Test
+    void 월간_음주_리포트_정상조회() {
+
+        // given
+        int goal = 15;
+        long drinkDays = 5L;
+        long drinkRecordCount = 8L;
+        int scoldedCount = 3;
+
+        UserGoalHistory goalHistory = mock(UserGoalHistory.class);
+        when(goalHistory.getMonthlyGoalCount()).thenReturn(goal);
+
+        when(userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(
+                        eq(userId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(goalHistory));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(
+                        eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkDays);
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(
+                        eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkRecordCount);
+
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(
+                        eq(userId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn((long) scoldedCount);
+
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        when(drinkReportConverter.toDto(
+                eq(goal),
+                eq(drinkRecordCount),
+                eq(drinkDays),
+                anyInt(),
+                eq(scoldedCount)
+        )).thenReturn(dto);
+
+        // when
+        DrinkReportResponseDTO result =
+                drinkReportService.drinkReport(userId, targetMonth);
+
+        // then
+        assertThat(result).isEqualTo(dto);
+
+        verify(userGoalHistoryRepository, times(1))
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(any(), any());
+
+        verify(drinkHistoryRepository, times(1))
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(any(), any(), any());
+
+        verify(drinkHistoryRepository, times(1))
+                .countByUserUserIdAndDrinkDateBetween(any(), any(), any());
+
+        verify(adviceRepository, times(1))
+                .countByUserUserIdAndAdvisedAtBetween(any(), any(), any());
+
+        verify(drinkReportConverter, times(1))
+                .toDto(eq(goal), eq(drinkRecordCount), eq(drinkDays), anyInt(), eq(scoldedCount));
+    }
+
+    @Test
+    void 목표가_없는_경우_기본값_15로_설정된다() {
+
+        // given
+        long drinkDays = 2L;
+        long drinkRecordCount = 5L;
+        int scoldedCount = 1;
+
+        when(userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(
+                        eq(userId), any(LocalDateTime.class)))
+                .thenReturn(Optional.empty());
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(
+                        eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkDays);
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(
+                        eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkRecordCount);
+
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(
+                        eq(userId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn((long) scoldedCount);
+
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        when(drinkReportConverter.toDto(
+                eq(15), // 기본 목표값
+                eq(drinkRecordCount),
+                eq(drinkDays),
+                anyInt(),
+                eq(scoldedCount)
+        )).thenReturn(dto);
+
+        // when
+        DrinkReportResponseDTO result =
+                drinkReportService.drinkReport(userId, targetMonth);
+
+        // then
+        assertThat(result).isEqualTo(dto);
+
+        verify(drinkReportConverter).toDto(
+                eq(15),
+                eq(drinkRecordCount),
+                eq(drinkDays),
+                anyInt(),
+                eq(scoldedCount)
+        );
+    }
+
+    /**
+     * 목표보다 적게 마신 경우 → achievementRate 정상 계산
+     */
+    @Test
+    void 음주일이_목표보다_적은_경우() {
+
+        int goal = 10;
+        long drinkDays = 2L;
+        long drinkRecordCount = 5L;
+
+        UserGoalHistory goalHistory = mock(UserGoalHistory.class);
+        when(goalHistory.getMonthlyGoalCount()).thenReturn(goal);
+
+        when(userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(eq(userId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(goalHistory));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkDays);
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkRecordCount);
+
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(eq(userId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(0L);
+
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        when(drinkReportConverter.toDto(goal, drinkRecordCount, drinkDays, 80, 0))
+                .thenReturn(dto);
+
+        DrinkReportResponseDTO result = drinkReportService.drinkReport(userId, targetMonth);
+
+        assertThat(result).isEqualTo(dto);
+    }
+
+    /**
+     *  음주일이 목표보다 많은 경우 → achievementRate = 0
+     */
+    @Test
+    void 음주일이_목표보다_많은_경우() {
+
+        int goal = 5;
+        long drinkDays = 8L;
+        long drinkRecordCount = 10L;
+
+        UserGoalHistory goalHistory = mock(UserGoalHistory.class);
+        when(goalHistory.getMonthlyGoalCount()).thenReturn(goal);
+
+        when(userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(eq(userId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(goalHistory));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkDays);
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkRecordCount);
+
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(eq(userId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(0L);
+
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        when(drinkReportConverter.toDto(goal, drinkRecordCount, drinkDays, 0, 0))
+                .thenReturn(dto);
+
+        DrinkReportResponseDTO result = drinkReportService.drinkReport(userId, targetMonth);
+
+        assertThat(result).isEqualTo(dto);
+    }
+
+    /**
+     * 목표가 0인 경우 → achievementRate = 0
+     */
+    @Test
+    void 목표가_0이면_달성률은_0이다() {
+
+        int goal = 0;
+        long drinkDays = 3L;
+        long drinkRecordCount = 5L;
+
+        UserGoalHistory goalHistory = mock(UserGoalHistory.class);
+        when(goalHistory.getMonthlyGoalCount()).thenReturn(goal);
+
+        when(userGoalHistoryRepository
+                .findTopByUserIdAndGoalSetAtLessThanEqualOrderByGoalSetAtDesc(eq(userId), any(LocalDateTime.class)))
+                .thenReturn(Optional.of(goalHistory));
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkDays);
+
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(eq(userId), any(LocalDate.class), any(LocalDate.class)))
+                .thenReturn(drinkRecordCount);
+
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(eq(userId), any(LocalDateTime.class), any(LocalDateTime.class)))
+                .thenReturn(0L);
+
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        when(drinkReportConverter.toDto(goal, drinkRecordCount, drinkDays, 0, 0))
+                .thenReturn(dto);
+
+        // when
+        DrinkReportResponseDTO result =
+                drinkReportService.drinkReport(userId, targetMonth);
+
+        // then
+        assertThat(result).isEqualTo(dto);
+
+        verify(drinkReportConverter).toDto(
+                goal,
+                drinkRecordCount,
+                drinkDays,
+                0,
+                0
+        );
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
음주 리포트의 달성률 계산 시 `isDrink` 여부와 관계없이 모든 기록이 집계되던 문제를 수정하고,
실제 음주일 기준으로 달성률이 계산되도록 로직을 개선했습니다. 또한 `DrinkReportService`의 단위 테스트를 추가했습니다.

## 🔗 관련 이슈  
Closes #131

## 🔍 작업 내용  
- 음주 리포트 달성률 계산 시 `isDrink=true` 데이터만 음주일로 집계하도록 수정
- "안 마셨어요" 기록이 음주 기록으로 포함되던 문제 해결
- `drinkRecordCount`(전체 기록 수)와 `drinkDays`(실제 음주일) 집계 로직 분리
- 절주 목표 달성률 계산 로직 안정화 (`goal <= 0` 예외 처리 포함)
- `DrinkReportServiceImpl` 단위 테스트 추가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  

### 고려 사항
- 음주 리포트에서 **기록 수(`drinkRecordCount`)와 실제 음주일(`drinkDays`)의 의미를 분리**했습니다.  
- `drinkRecordCount`는 `isDrink=true/false` 여부와 관계없이 **기록 자체의 개수**를 의미하며,  
  `drinkDays`는 **실제로 술을 마신 날(`isDrink=true`)** 만 집계하도록 구현했습니다.
- 절주 목표 달성률 계산 시 `goal <= 0`인 경우 0을 반환하도록 하여 **0으로 나누는 예외 상황을 방지**했습니다.

### 성능 관련 고려사항
현재 리포트 조회 시 다음과 같은 DB 조회가 발생합니다.

1. 사용자 목표 조회 (`UserGoalHistory`)
2. 실제 음주일 count (`DrinkHistory`, `isDrink=true`)
3. 전체 기록 count (`DrinkHistory`)
4. 꾸짖음 횟수 count (`Advice`)

총 **4개의 count query**가 실행됩니다.  
현재 트래픽 수준에서는 큰 문제가 없지만, 추후 트래픽 증가 시 다음과 같은 최적화를 고려할 수 있습니다.

### 추후 리팩토링 / 최적화 아이디어

1️⃣ **DrinkHistory 집계 쿼리 통합**

현재

```
countByUserUserIdAndDrinkDateBetween
countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween
```

두 번 조회하는 것을 다음과 같이 **단일 query로 집계**할 수 있습니다.

```sql
SELECT
    COUNT(*) AS drinkRecordCount,
    SUM(CASE WHEN is_drink = true THEN 1 ELSE 0 END) AS drinkDays
FROM drink_history
WHERE user_id = ?
AND drink_date BETWEEN ? AND ?
```

2️⃣ **Report 전용 Projection / Query 도입**

리포트 전용 DTO Projection을 만들어 **DB 조회 횟수를 줄일 수 있습니다.**

3️⃣ **리포트 캐싱**

월 리포트 데이터는 **하루 단위로만 변화**하기 때문에  
추후 Redis 캐싱 등을 통해 조회 성능 개선을 고려할 수 있습니다.

현재 PR에서는 **가독성과 유지보수성을 우선으로 구현**하였으며,  
추후 트래픽 증가 시 위 방식으로 리팩토링할 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 음료 보고서 조회 알고리즘 최적화 및 목표 달성률 계산 로직 개선

* **Tests**
  * 음료 보고서 서비스의 포괄적인 단위 테스트 추가 (월별 데이터 조회, 기본값 처리, 달성률 계산 등 다양한 시나리오 포함)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->