### PR TITLE
Feat/#137 main add onboarding status

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
@@ -24,4 +24,6 @@ public class MainResponseDto {
 
     private boolean didRecordYesterday; // 어제 기록 완료 여부
     private boolean didRecordToday;  // 오늘 기록 완료 여부
+
+    private boolean isOnboarded; // 온보딩 테스트 완료 여부
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -33,9 +33,7 @@ public class MainServiceImpl implements MainService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-
-        // Puppy puppy = puppyRepository.findByUser_UserId(userId).orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
-
+        
         Optional<Puppy> puppyOpt = puppyRepository.findByUser_UserId(userId);
 
         // 온보딩 미완료

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -33,9 +34,19 @@ public class MainServiceImpl implements MainService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        Puppy puppy = puppyRepository.findByUser_UserId(userId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
+        // Puppy puppy = puppyRepository.findByUser_UserId(userId).orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
 
+        Optional<Puppy> puppyOpt = puppyRepository.findByUser_UserId(userId);
+
+        // 온보딩 미완료
+        if (puppyOpt.isEmpty()) {
+            return MainResponseDto.builder()
+                    .isOnboarded(false)
+                    .build();
+        }
+
+        // 온보딩 완료
+        Puppy puppy = puppyOpt.get();
         PuppyLevel level = puppy.getPuppyLevel();
 
         int percent = calculateExp(puppy, level);
@@ -55,6 +66,7 @@ public class MainServiceImpl implements MainService {
         boolean didRecordToday = drinkHistoryRepository.existsByUserUserIdAndDrinkDate(userId, today);
 
         return MainResponseDto.builder()
+                .isOnboarded(true)
                 .puppyLevel(level.getPuppyLevel())
                 .puppyLevelName(level.getLevelName())
                 .puppyLevelPercent(percent)

--- a/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
@@ -1,0 +1,100 @@
+package com.umc.puppymode2.domain.puppy.service;
+
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.puppy.dto.MainResponseDto;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.entity.PuppyLevel;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import com.umc.puppymode2.global.exception.GeneralException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class MainServiceImplTest {
+
+    @Mock
+    private PuppyRepository puppyRepository;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private DrinkHistoryRepository drinkHistoryRepository;
+    @Mock
+    private UserGoalHistoryRepository userGoalHistoryRepository;
+    @Mock
+    private UserContext userContext;
+
+    @InjectMocks
+    private MainServiceImpl mainService;
+
+    private final Long userId = 1L;
+
+    @Test
+    void 온보딩_미완료_유저가_메인을_조회하면_isOnboarded가_false이다() {
+        // given
+        User user = mock(User.class);
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertFalse(result.isOnboarded());
+    }
+
+    @Test
+    void 온보딩_완료_유저가_메인을_조회하면_isOnboarded가_true이다() {
+        // given
+        User user = mock(User.class);
+
+        PuppyLevel level = PuppyLevel.builder()
+                .puppyLevel(1)
+                .levelMinExp(0L)
+                .levelMaxExp(100L)
+                .build();
+
+        Puppy puppy = Puppy.builder()
+                .puppyLevel(level)
+                .puppyExp(50)
+                .puppyName("테스트강아지")
+                .build();
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertTrue(result.isOnboarded());
+    }
+
+    @Test
+    void 존재하지_않는_유저가_메인을_조회하면_예외가_발생한다() {
+        // given
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(GeneralException.class,
+                () -> mainService.getMainPageInfo());
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
메인 화면 조회 API 응답에 온보딩 완료 여부(isOnboarded) 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #137

## 🔍 작업 내용  
- `MainResponseDto`에 `isOnboarded` 필드 추가
- 온보딩 미완료 시 `isOnboarded: false` 반환, 완료 시 기존 메인 데이터와 함께 `isOnboarded: true` 반환
- `MainServiceImplTest` 테스트 코드 추가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 사용자의 온보딩 완료 상태를 추적하는 기능 추가
  
* **개선 사항**
  * 퍼피 기록이 없는 사용자도 오류 없이 메인 페이지에 정상 접근 가능하도록 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->