### PR TITLE
Feat/#141 exp name goal

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -21,4 +21,7 @@ public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long
                                  @Param("end") LocalDate end);
     long countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
     long countByUserUserIdAndIsDrinkTrue(Long userId);
+
+    // 월간 목표 달성 체크 - 음주 안 한 날(isDrink=false) 카운트
+    long countByUserUserIdAndIsDrinkFalseAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -46,7 +46,7 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
         int drinkExp = 10;
 
         // 월간 목표 달성 여부 체크 -> 달성시 300 exp 추가 지급 (중복 지급x)
-        LocalDate today = LocalDate.now();
+        LocalDate today = dto.getDrinkDate();
         LocalDate firstDay = today.withDayOfMonth(1);
         LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
 

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -5,6 +5,8 @@ import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.puppy.entity.Puppy;
 import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
 import com.umc.puppymode2.domain.user.entity.User;
@@ -15,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -22,6 +26,7 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
     private final UserRepository userRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final PuppyRepository puppyRepository;
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
 
     @Override
     public DrinkHistoryResponseDTO recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
@@ -36,8 +41,28 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
 
         Puppy puppy = puppyRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
-        int updatedExp = puppy.getPuppyExp() + 10;
-        puppy.setPuppyExp(updatedExp);
+
+        // 음주 기록 경험치
+        int drinkExp = 10;
+
+        // 월간 목표 달성 여부 체크 -> 달성시 300 exp 추가 지급 (중복 지급x)
+        LocalDate today = LocalDate.now();
+        LocalDate firstDay = today.withDayOfMonth(1);
+        LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
+
+        UserGoalHistory goal = userGoalHistoryRepository.findByUserIdAndGoalMonth(userId, firstDay).orElse(null);
+
+        if (goal != null && !goal.isRewarded() && Boolean.FALSE.equals(dto.getIsDrink())) {
+            long nonDrinkCount = drinkHistoryRepository
+                    .countByUserUserIdAndIsDrinkFalseAndDrinkDateBetween(userId, firstDay, lastDay);
+
+            if (nonDrinkCount >= goal.getMonthlyGoalCount()) {
+                drinkExp += 300;
+                goal.markRewarded();
+            }
+        }
+
+        puppy.setPuppyExp(puppy.getPuppyExp() + drinkExp);
 
         puppyRepository.save(puppy);
 

--- a/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/entity/UserGoalHistory.java
@@ -63,4 +63,13 @@ public class UserGoalHistory {
     @UpdateTimestamp
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;
+
+    // 월간 목표 달성 경험치 지급 여부
+    @Column(name = "is_rewarded", nullable = false)
+    private boolean rewarded = false;
+
+    // 목표 달성 경험치 지급 처리
+    public void markRewarded() {
+        this.rewarded = true;
+    }
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/PuppyNameServiceImpl.java
@@ -25,6 +25,10 @@ public class PuppyNameServiceImpl implements PuppyNameService {
         Puppy puppy = puppyRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
 
+        if (!puppy.isCustomName()) {
+            puppy.setPuppyExp(puppy.getPuppyExp() + 10);
+        }
+
         puppy.setPuppyName(requestDto.getPuppyName());
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/service/UserNameServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/service/UserNameServiceImpl.java
@@ -24,6 +24,10 @@ public class UserNameServiceImpl implements UserNameService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
+        if (!user.isCustomName()) {
+            user.getPuppy().setPuppyExp(user.getPuppy().getPuppyExp() + 10);
+        }
+
         user.setUsername(requestDto.getMyName());
     }
 }


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
경험치 지급 기능 추가: 강아지 및 사용자 이름 변경 시 20 exp, 월간 목표 달성 시 300 exp

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #141 

## 🔍 작업 내용  
- `UserGoalHistory`에 `is_rewarded` 컬럼 추가 및 `markRewarded()` 메서드 구현
- `DrinkHistoryRepository`에 비음주 날 카운트 쿼리 추가 
- 음주 기록 시 이번 달 비음주 날 수가 월간 목표 이상이면 300 exp 추가 지급 (중복 지급 방지)

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 월간 음주 목표 달성 시 보너스 경험치(+300) 지급 추가
  * 사용자명 또는 강아지 이름 변경 시 경험치(+10) 획득 추가

* **Improvements**
  * 월간 목표 보상 중복 지급 방지 로직 도입
  * 월별 음주 기록 집계로 보상 기준을 정확히 반영하도록 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->