### PR TITLE
[FEAT] 사용자 상태 조회 추가 #144

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface PuppyRepository extends JpaRepository<Puppy, Long> {
     Optional<Puppy> findByUser_UserId(Long userId);
+
+    boolean existsByUser_UserId(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.umc.puppymode2.domain.user.auth.controller;
 
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenRequestDTO;
-import com.umc.puppymode2.domain.user.auth.dto.ReissueTokenResponseDTO;
+import com.umc.puppymode2.domain.user.auth.dto.*;
+import com.umc.puppymode2.domain.user.auth.service.UserAuthService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
@@ -16,18 +16,16 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 
 /**
  * 인증 관련 API 컨트롤러
- *
- * <p>토큰 재발급 및 로그아웃 기능을 제공합니다.</p>
+ * <p>
+ * 토큰 재발급 및 로그아웃 기능을 제공합니다.
  */
 @Slf4j
 @RequiredArgsConstructor
@@ -39,18 +37,17 @@ public class AuthController {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtTokenService jwtTokenService;
     private final UserContext userContext;
+    private final UserAuthService userAuthService;
 
     /**
      * Refresh Token 기반 토큰 재발급
-     *
-     * <p>만료된 Access Token을 갱신하기 위해 Refresh Token을 사용합니다.</p>
-     *
-     * <h6>처리 과정:</h6>
-     * <ol>
-     *   <li>요청된 Refresh Token과 Redis에 저장된 토큰 비교 (상수 시간 비교)</li>
-     *   <li>일치할 경우 새로운 Access Token과 Refresh Token 발급</li>
-     *   <li>기존 Refresh Token 무효화, 새 토큰으로 교체</li>
-     * </ol>
+     * <p>
+     * 만료된 Access Token을 갱신하기 위해 Refresh Token을 사용합니다.
+     * <p>
+     * 처리 과정:
+     * - 요청된 Refresh Token과 Redis에 저장된 토큰 비교 (상수 시간 비교)
+     * - 일치할 경우 새로운 Access Token과 Refresh Token 발급
+     * - 기존 Refresh Token 무효화, 새 토큰으로 교체
      *
      * @param dto Refresh Token을 포함한 요청 DTO
      * @return 새로운 Access Token과 Refresh Token
@@ -115,17 +112,15 @@ public class AuthController {
 
     /**
      * 로그아웃
-     *
-     * <p>Redis에 저장된 Refresh Token을 삭제하여 로그아웃 처리합니다.</p>
-     *
-     * <h6>처리 과정:</h6>
-     * <ol>
-     *   <li>현재 사용자의 userId 추출 (Access Token에서)</li>
-     *   <li>Redis에서 해당 userId의 Refresh Token 삭제</li>
-     *   <li>삭제 결과 로깅</li>
-     * </ol>
-     *
-     * <p><strong>참고:</strong> Access Token은 클라이언트에서 폐기해야 합니다.</p>
+     * <p>
+     * Redis에 저장된 Refresh Token을 삭제하여 로그아웃 처리합니다.
+     * <p>
+     * 처리 과정:
+     * - 현재 사용자의 userId 추출 (Access Token에서)
+     * - Redis에서 해당 userId의 Refresh Token 삭제
+     * - 삭제 결과 로깅
+     * <p>
+     * 참고: Access Token은 클라이언트에서 폐기해야 합니다.
      */
     @Operation(
             summary = "로그아웃",
@@ -169,5 +164,42 @@ public class AuthController {
                 SuccessStatus.AUTH_LOGOUT_SUCCESS.getCode(),
                 SuccessStatus.AUTH_LOGOUT_SUCCESS.getMessage()
         );
+    }
+
+    /**
+     * 사용자 정보 조회
+     * <p>
+     * - 토큰이 유효한지 확인합니다.
+     * - 온보딩 여부를 반환합니다. (puppy 존재 여부로 판단)
+     */
+    @Operation(
+            summary = "현재 사용자 상태 조회",
+            description = """
+                    현재 사용자의 상태를 조회합니다.
+                    - 온보딩 여부
+                    - 토큰이 유효하지 않은 경우 401 반환
+                    """
+    )
+    @GetMapping("/me")
+    @ApiSuccessResponseExample(
+            status = SuccessStatus.AUTH_ME_SUCCESS,
+            responseType = AuthMeResponseDTO.class
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus.AUTH_INVALID_TOKEN,
+            ErrorStatus.USER_NOT_FOUND,
+            ErrorStatus._INTERNAL_SERVER_ERROR
+    })
+    public ResponseEntity<ApiResponse<AuthMeResponseDTO>> me() {
+
+        Long userId = userContext.getCurrentUserId();
+
+        AuthMeResponseDTO response = userAuthService.getAuthMe(userId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                response,
+                SuccessStatus.AUTH_ME_SUCCESS.getCode(),
+                SuccessStatus.AUTH_ME_SUCCESS.getMessage()
+        ));
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -25,7 +25,7 @@ import java.security.MessageDigest;
 /**
  * 인증 관련 API 컨트롤러
  * <p>
- * 토큰 재발급 및 로그아웃 기능을 제공합니다.
+ * 토큰 재발급 및 로그아웃, 사용자 상태 조회 기능을 제공합니다.
  */
 @Slf4j
 @RequiredArgsConstructor

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
@@ -1,0 +1,14 @@
+package com.umc.puppymode2.domain.user.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "현재 사용자 상태 조회 응답 DTO")
+public record AuthMeResponseDTO(
+
+        @Schema(
+                description = "온보딩 완료 여부",
+                example = "true"
+        )
+        boolean isOnboarded
+) {
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
@@ -10,7 +10,7 @@ import com.umc.puppymode2.domain.user.auth.enums.Provider;
 public interface UserAuthService {
 
     /**
-     * 새로운 회윈을 생성 또는 갱신합니다.
+     * 새로운 회원을 생성 또는 갱신합니다.
      */
     LoginResponseDTO createOrUpdateUser(UserAuthInfoDTO userInfo, Provider authProvider, String refreshToken);
 

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthService.java
@@ -1,6 +1,7 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
 
+import com.umc.puppymode2.domain.user.auth.dto.AuthMeResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
@@ -8,7 +9,9 @@ import com.umc.puppymode2.domain.user.auth.enums.Provider;
 
 public interface UserAuthService {
 
-    // 새로운 회윈 생성 또는 갱신
+    /**
+     * 새로운 회윈을 생성 또는 갱신합니다.
+     */
     LoginResponseDTO createOrUpdateUser(UserAuthInfoDTO userInfo, Provider authProvider, String refreshToken);
 
     /**
@@ -20,4 +23,9 @@ public interface UserAuthService {
      * 회원탈퇴 처리를 합니다.
      */
     void withdrawUser(Long userId);
+
+    /**
+     * 온보딩 여부를 반환합니다.
+     */
+    AuthMeResponseDTO getAuthMe(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -1,5 +1,7 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.auth.dto.AuthMeResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.UserAuthInfoDTO;
 import com.umc.puppymode2.domain.user.auth.enums.Provider;
@@ -8,9 +10,11 @@ import com.umc.puppymode2.domain.user.entity.User;
 import com.umc.puppymode2.domain.user.entity.enums.UserStatus;
 import com.umc.puppymode2.domain.user.repository.SocialAuthRepository;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.auth.token.JwtTokenProvider;
 import com.umc.puppymode2.global.auth.token.JwtTokenService;
 import com.umc.puppymode2.global.config.RedisConfig;
+import com.umc.puppymode2.global.exception.GeneralException;
 import com.umc.puppymode2.global.security.UserAuthentication;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,6 +38,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final JwtTokenService jwtTokenService;
     private final SocialAuthRepository socialAuthRepository;
     private final RedisConfig.RedisHealthIndicator redisHealthIndicator;
+    private final PuppyRepository puppyRepository;
 
     @Transactional
     @Override
@@ -203,5 +208,23 @@ public class UserAuthServiceImpl implements UserAuthService {
 
         userRepository.save(user);
         log.info("[Withdraw] 회원탈퇴 처리 완료 - userId: {}", userId);
+    }
+
+    /**
+     * 사용자의 온보딩 완료 여부를 조회합니다.
+     * - puppy 존재 여부를 기준으로 판단
+     *
+     * @param userId 사용자 ID
+     * @return 사용자 상태 조회 응답 DTO
+     */
+    @Override
+    @Transactional(readOnly = true)
+    public AuthMeResponseDTO getAuthMe(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        boolean isOnboarded = puppyRepository.existsByUser_UserId(user.getUserId());
+
+        return new AuthMeResponseDTO(isOnboarded);
     }
 }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -19,6 +19,7 @@ public enum SuccessStatus implements BaseCode {
     AUTH_REISSUE_SUCCESS(HttpStatus.OK, "AUTH_REISSUE200", "토큰 재발급 성공"),
     AUTH_LOGOUT_SUCCESS(HttpStatus.OK, "AUTH_LOGOUT200", "로그아웃 성공"),
     AUTH_WITHDRAW_SUCCESS(HttpStatus.OK, "AUTH_WITHDRAW200", "회원탈퇴 성공"),
+    AUTH_ME_SUCCESS(HttpStatus.OK, "AUTH_ME200", "사용자 정보 조회 성공"),
 
     // 음주 기록
     DRINK_HISTORY_RECORD_SUCCESS(HttpStatus.OK, "DRINK_HISTORY200", "음주 기록 성공"),


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
사용자 상태 조회 api 구현했습니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #144 

## 🔍 작업 내용  
- 온보딩 여부 반환

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 현재 사용자의 온보딩 상태를 조회할 수 있는 새로운 API 엔드포인트 추가
  * 사용자 인증 정보 조회 기능 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->