### PR TITLE
[REFACTOR] reissue 로직 수정 #146

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -12,6 +12,7 @@ import com.umc.puppymode2.global.config.RequiresRedis;
 import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
 import com.umc.puppymode2.global.config.swagger.ApiSuccessResponseExample;
 import com.umc.puppymode2.global.exception.GeneralException;
+import com.umc.puppymode2.global.security.JwtValidationType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -42,15 +43,8 @@ public class AuthController {
     /**
      * Refresh Token 기반 토큰 재발급
      * <p>
-     * 만료된 Access Token을 갱신하기 위해 Refresh Token을 사용합니다.
-     * <p>
-     * 처리 과정:
-     * - 요청된 Refresh Token과 Redis에 저장된 토큰 비교 (상수 시간 비교)
-     * - 일치할 경우 새로운 Access Token과 Refresh Token 발급
-     * - 기존 Refresh Token 무효화, 새 토큰으로 교체
-     *
-     * @param dto Refresh Token을 포함한 요청 DTO
-     * @return 새로운 Access Token과 Refresh Token
+     * RT 에서 userId 파싱
+     * redis RT와 상수 시간 일치 여부로 검증합니다.
      */
     @Operation(
             summary = "토큰 재발급",
@@ -58,14 +52,15 @@ public class AuthController {
                     Refresh Token을 기반으로 Access Token과 Refresh Token을 재발급합니다.
                     
                     **처리 과정:**
-                    1. Refresh Token 검증 (상수 시간 비교로 타이밍 공격 방지)
-                    2. 새로운 Access/Refresh Token 생성
-                    3. 기존 Refresh Token 무효화
+                    1. RT 서명 및 만료 검증
+                    2. RT에서 userId 추출
+                    3. Redis 저장 RT와 상수 시간 비교
+                    4. 새로운 AT/RT 발급 및 RT 교체
                     
                     **주의:**
                     - Redis 연결 필수
-                    - Refresh Token이 만료되었거나 일치하지 않으면 실패
-                    - 보안을 위해 Refresh Token도 갱신됨
+                    - RT가 만료되었거나 불일치하면 실패
+                    - 보안을 위해 RT도 갱신됨 (RTR 방식)
                     """
     )
     @PostMapping("/reissue")
@@ -79,29 +74,38 @@ public class AuthController {
             ErrorStatus.REDIS_CONNECTION_FAILURE,
             ErrorStatus.AUTH_REFRESH_TOKEN_INVALID
     })
-    public ApiResponse<ReissueTokenResponseDTO> reissue(@RequestBody ReissueTokenRequestDTO dto) {
+    public ApiResponse<ReissueTokenResponseDTO> reissue(
+            @RequestBody ReissueTokenRequestDTO dto) {
 
         String incomingRefreshToken = dto.refreshToken();
 
-        Long userId = userContext.getCurrentUserId();
-        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
+        // RT 서명 및 만료 검증
+        JwtValidationType validationType = jwtTokenProvider.validateToken(incomingRefreshToken);
+        if (validationType != JwtValidationType.VALID_JWT) {
+            log.warn("[REISSUE] 유효하지 않은 RT - type={}", validationType);
+            throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
+        }
 
-        // 상수 시간 비교 (타이밍 공격 방지)
+        // RT에서 userId 파싱
+        Long userId = jwtTokenProvider.parseUserId(incomingRefreshToken);
+
+        // Redis 저장 RT와 상수 시간 비교
+        String savedRefreshToken = jwtTokenService.getRefreshToken(userId);
         if (savedRefreshToken == null || !MessageDigest.isEqual(
                 savedRefreshToken.getBytes(StandardCharsets.UTF_8),
                 incomingRefreshToken.getBytes(StandardCharsets.UTF_8)
         )) {
-            log.warn("[REISSUE] 유효하지 않은 Refresh Token - userId={}", userId);
+            log.warn("[REISSUE] RT 불일치 - userId={}", userId);
             throw new GeneralException(ErrorStatus.AUTH_REFRESH_TOKEN_INVALID);
         }
 
-        // Refresh Token 교체
+        // 토큰 교체
         String newAccessToken = jwtTokenProvider.generateAccessToken(userId);
         String newRefreshToken = jwtTokenProvider.generateRefreshToken(userId);
         jwtTokenService.saveRefreshToken(userId, newRefreshToken);
 
         Long expiresIn = jwtTokenProvider.getAccessTokenExpirySeconds();
-        log.info("[REISSUE] Refresh Token 재발급 완료 - userId={}", userId);
+        log.info("[REISSUE] 토큰 재발급 완료 - userId={}", userId);
 
         return ApiResponse.onSuccess(
                 new ReissueTokenResponseDTO(newAccessToken, newRefreshToken, expiresIn),
@@ -130,12 +134,10 @@ public class AuthController {
                     **처리 과정:**
                     1. Access Token에서 userId 추출
                     2. Redis에서 Refresh Token 삭제
-                    3. 삭제 결과 반환
                     
                     **주의:**
                     - Redis 연결 필수
                     - Access Token은 클라이언트에서 폐기 필요
-                    - 이미 로그아웃된 상태여도 성공 처리
                     """
     )
     @PostMapping("/logout")
@@ -193,7 +195,6 @@ public class AuthController {
     public ResponseEntity<ApiResponse<AuthMeResponseDTO>> me() {
 
         Long userId = userContext.getCurrentUserId();
-
         AuthMeResponseDTO response = userAuthService.getAuthMe(userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -70,7 +70,6 @@ public class AuthController {
             responseType = ReissueTokenResponseDTO.class
     )
     @ApiErrorCodeExamples({
-            ErrorStatus.AUTH_INVALID_TOKEN,
             ErrorStatus.REDIS_CONNECTION_FAILURE,
             ErrorStatus.AUTH_REFRESH_TOKEN_INVALID
     })

--- a/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenProvider.java
+++ b/src/main/java/com/umc/puppymode2/global/auth/token/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.crypto.SecretKey;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 
@@ -21,8 +22,8 @@ import java.util.Date;
 public class JwtTokenProvider {
 
     private static final String USER_ID = "userId";
-    private static final Long ACCESS_TOKEN_EXPIRE_TIME = 1000L * 60 * 60; // 1시간
-    private static final Long REFRESH_TOKEN_EXPIRE_TIME = 1000L * 60 * 60 * 24 * 14; // 14일
+    private static final Duration ACCESS_TOKEN_EXPIRE_TIME = Duration.ofHours(1);
+    private static final Duration REFRESH_TOKEN_EXPIRE_TIME = Duration.ofDays(14);
 
     @Value("${auth.jwt.secret}")
     private String JWT_SECRET;
@@ -54,13 +55,13 @@ public class JwtTokenProvider {
      * JWT를 생성합니다.
      *
      * @param userId
-     * @param expiryMillis
+     * @param expiry
      * @param tokenType
      * @return
      */
-    public String generateToken(Long userId, long expiryMillis, String tokenType) {
+    public String generateToken(Long userId, Duration expiry, String tokenType) {
         Date now = new Date();
-        Date expiryDate = new Date(now.getTime() + expiryMillis);
+        Date expiryDate = new Date(now.getTime() + expiry.toMillis());
 
         final Claims claims = Jwts.claims()
                 .setIssuedAt(now)
@@ -116,12 +117,17 @@ public class JwtTokenProvider {
         }
 
         Claims claims = getTokenBody(token);
-        Object userIdObj = claims.get(USER_ID);
+        return extractUserId(claims);
+    }
 
+    /**
+     * userId 를 파싱합니다.
+     */
+    private Long extractUserId(Claims claims) {
+        Object userIdObj = claims.get(USER_ID);
         if (userIdObj == null) {
             throw new IllegalArgumentException("Invalid JWT: missing userId");
         }
-
         try {
             return Long.parseLong(userIdObj.toString());
         } catch (NumberFormatException e) {
@@ -144,7 +150,7 @@ public class JwtTokenProvider {
      * 액세스 토큰 만료 시간을 초 단위로 반환합니다.
      */
     public Long getAccessTokenExpirySeconds() {
-        return ACCESS_TOKEN_EXPIRE_TIME / 1000L;
+        return ACCESS_TOKEN_EXPIRE_TIME.toSeconds();
     }
 
 }

--- a/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/security/SecurityConfig.java
@@ -22,7 +22,8 @@ public class SecurityConfig {
             "/auth/kakao/login/**",
             "/auth/apple/login/**",
             "/auth/apple/callback",
-            "/auth/apple/callback/**"
+            "/auth/apple/callback/**",
+            "/auth/reissue"
     };
 
     public static final String[] HEALTH_WHITELIST = {


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
reissue 로직 개선

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #146

## 🔍 작업 내용  
- 미인증 경로 허용
- RT userid 파싱 후 redis RT 일치여부 확인
- token 생성 시 만료 시간 duration()으로 가독성 개선

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안 강화**
  * 토큰 갱신 시 JWT 서명 및 만료 검증 절차 추가로 보안성 강화
  * 저장된 토큰과의 비교 검증 로직 개선
  * 토큰 갱신 엔드포인트 접근 제어 업데이트

* **개선사항**
  * 토큰 만료 처리 로직 최적화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->