### PR TITLE
[FIX] 월간 목표 달성 경험치 지급 기준 수정 #148

### DIFF
--- a/src/main/java/com/umc/puppymode2/Puppymode2Application.java
+++ b/src/main/java/com/umc/puppymode2/Puppymode2Application.java
@@ -2,7 +2,9 @@ package com.umc.puppymode2;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class Puppymode2Application {
 

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/DrinkHistoryRepository.java
@@ -22,6 +22,19 @@ public interface DrinkHistoryRepository extends JpaRepository<DrinkHistory, Long
     long countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
     long countByUserUserIdAndIsDrinkTrue(Long userId);
 
-    // 월간 목표 달성 체크 - 음주 안 한 날(isDrink=false) 카운트
-    long countByUserUserIdAndIsDrinkFalseAndDrinkDateBetween(Long userId, LocalDate start, LocalDate end);
+    // 유저별 이번 달 전체 음주 기록 수 + 음주 횟수
+    @Query("""
+        SELECT d.user.userId AS userId,
+               COUNT(d) AS totalCount,
+               SUM(CASE WHEN d.isDrink = true THEN 1 ELSE 0 END) AS drinkCount
+        FROM DrinkHistory d
+        WHERE d.user.userId IN :userIds
+          AND d.drinkDate BETWEEN :firstDay AND :lastDay
+        GROUP BY d.user.userId
+    """)
+    List<UserDrinkCountProjection> countMonthlyDrinkByUserIds(
+            @Param("userIds") List<Long> userIds,
+            @Param("firstDay") LocalDate firstDay,
+            @Param("lastDay") LocalDate lastDay
+    );
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/UserDrinkCountProjection.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/repository/UserDrinkCountProjection.java
@@ -1,0 +1,7 @@
+package com.umc.puppymode2.domain.drinkhistory.repository;
+
+public interface UserDrinkCountProjection {
+    Long getUserId();
+    Long getTotalCount();
+    Long getDrinkCount();
+}

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -5,8 +5,6 @@ import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryRequestDTO;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.entity.DrinkHistory;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
-import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
-import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.puppy.entity.Puppy;
 import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
 import com.umc.puppymode2.domain.user.entity.User;
@@ -17,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
-
 @Service
 @Transactional
 @RequiredArgsConstructor
@@ -26,7 +22,6 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
     private final UserRepository userRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final PuppyRepository puppyRepository;
-    private final UserGoalHistoryRepository userGoalHistoryRepository;
 
     @Override
     public DrinkHistoryResponseDTO recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
@@ -42,29 +37,7 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
         Puppy puppy = puppyRepository.findByUser_UserId(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
 
-        // 음주 기록 경험치
-        int drinkExp = 10;
-
-        // 월간 목표 달성 여부 체크 -> 달성시 300 exp 추가 지급 (중복 지급x)
-        LocalDate today = dto.getDrinkDate();
-        LocalDate firstDay = today.withDayOfMonth(1);
-        LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
-
-        UserGoalHistory goal = userGoalHistoryRepository.findByUserIdAndGoalMonth(userId, firstDay).orElse(null);
-
-        if (goal != null && !goal.isRewarded() && Boolean.FALSE.equals(dto.getIsDrink())) {
-            long nonDrinkCount = drinkHistoryRepository
-                    .countByUserUserIdAndIsDrinkFalseAndDrinkDateBetween(userId, firstDay, lastDay);
-
-            if (nonDrinkCount >= goal.getMonthlyGoalCount()) {
-                drinkExp += 300;
-                goal.markRewarded();
-            }
-        }
-
-        puppy.setPuppyExp(puppy.getPuppyExp() + drinkExp);
-
-        puppyRepository.save(puppy);
+        puppy.setPuppyExp(puppy.getPuppyExp() + 10);
 
         return DrinkHistoryConverter.toResponseDTO(drinkHistory.getDrinkHistoryId(), puppy.getPuppyExp());
     }

--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import java.time.LocalDate;
 
@@ -30,4 +31,8 @@ public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory
     @Modifying
     @Query("DELETE FROM UserGoalHistory ugh WHERE ugh.userId = :userId")
     void deleteAllByUserId(@Param("userId") Long userId);
+
+    // 이번 달 보상 미지급 목록 조회
+    List<UserGoalHistory> findAllByGoalMonthAndRewardedFalse(LocalDate goalMonth);
+
 }

--- a/src/main/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalScheduler.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalScheduler.java
@@ -30,6 +30,7 @@ public class MonthlyGoalScheduler {
      * 매월 마지막 날 23:59에 실행되는 월간 목표 달성 보상 스케줄러
      * 이번 달 음주 기록이 있고 실제 음주 횟수가 목표 이하인 유저에게 경험치 300 지급
      */
+    // TODO: 멀티 인스턴스 배포 시 중복 실행 방지를 위해 ShedLock 적용 필요
     @Scheduled(cron = "0 59 23 L * *", zone = "Asia/Seoul")
     @Transactional
     public void evaluateMonthlyGoals() {

--- a/src/main/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalScheduler.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalScheduler.java
@@ -1,0 +1,87 @@
+package com.umc.puppymode2.domain.goal.scheduler;
+
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.drinkhistory.repository.UserDrinkCountProjection;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Component
+@RequiredArgsConstructor
+public class MonthlyGoalScheduler {
+
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
+    private final DrinkHistoryRepository drinkHistoryRepository;
+    private final PuppyRepository puppyRepository;
+
+    /**
+     * 매월 마지막 날 23:59에 실행되는 월간 목표 달성 보상 스케줄러
+     * 이번 달 음주 기록이 있고 실제 음주 횟수가 목표 이하인 유저에게 경험치 300 지급
+     */
+    @Scheduled(cron = "0 59 23 L * *", zone = "Asia/Seoul")
+    @Transactional
+    public void evaluateMonthlyGoals() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        LocalDate firstDay = today.withDayOfMonth(1);
+        LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
+
+        // 이번 달 목표가 있고 아직 보상을 받지 않은 유저 목록 조회
+        List<UserGoalHistory> goals = userGoalHistoryRepository
+                .findAllByGoalMonthAndRewardedFalse(firstDay);
+
+        if (goals.isEmpty()) return;
+
+        List<Long> userIds = goals.stream()
+                .map(UserGoalHistory::getUserId)
+                .distinct()
+                .collect(Collectors.toList());
+
+        // 보상 대상 유저들의 강아지 조회
+        Map<Long, Puppy> puppyMap = puppyRepository.findAllByUserUserIdIn(userIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        p -> p.getUser().getUserId(),
+                        Function.identity()
+                ));
+
+        // 보상 대상 유저들의 이번 달 음주 기록 통계 조회
+        Map<Long, UserDrinkCountProjection> drinkStatMap = drinkHistoryRepository
+                .countMonthlyDrinkByUserIds(userIds, firstDay, lastDay)
+                .stream()
+                .collect(Collectors.toMap(
+                        UserDrinkCountProjection::getUserId,
+                        Function.identity()
+                ));
+
+        for (UserGoalHistory goal : goals) {
+            Long userId = goal.getUserId();
+            UserDrinkCountProjection stat = drinkStatMap.get(userId);
+
+            // 목표만 세우고 기록 안 한 경우 경험치 미지급
+            if (stat == null || stat.getTotalCount() == 0) continue;
+
+            long drinkCount = stat.getDrinkCount() == null ? 0L : stat.getDrinkCount();
+
+            // 이번 달 음주 횟수가 목표 이하면 달성 - 경험치 지급
+            if (drinkCount <= goal.getMonthlyGoalCount()) {
+                Puppy puppy = puppyMap.get(userId);
+                if (puppy == null) continue;
+
+                puppy.setPuppyExp(puppy.getPuppyExp() + 300);
+                goal.markRewarded();
+            }
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/repository/PuppyRepository.java
@@ -3,10 +3,13 @@ package com.umc.puppymode2.domain.puppy.repository;
 import com.umc.puppymode2.domain.puppy.entity.Puppy;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PuppyRepository extends JpaRepository<Puppy, Long> {
     Optional<Puppy> findByUser_UserId(Long userId);
 
     boolean existsByUser_UserId(Long userId);
+
+    List<Puppy> findAllByUserUserIdIn(List<Long> userIds);
 }

--- a/src/test/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalSchedulerTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/scheduler/MonthlyGoalSchedulerTest.java
@@ -1,0 +1,221 @@
+package com.umc.puppymode2.domain.goal.scheduler;
+
+import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.domain.drinkhistory.repository.UserDrinkCountProjection;
+import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MonthlyGoalSchedulerTest {
+
+    @Mock
+    private UserGoalHistoryRepository userGoalHistoryRepository;
+
+    @Mock
+    private DrinkHistoryRepository drinkHistoryRepository;
+
+    @Mock
+    private PuppyRepository puppyRepository;
+
+    @InjectMocks
+    private MonthlyGoalScheduler monthlyGoalScheduler;
+
+    @Test
+    @DisplayName("이번 달 목표가 없으면 아무 작업도 수행하지 않는다")
+    void 이번달_목표가_없으면_아무것도_실행되지_않는다() {
+        // given
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of());
+
+        // when
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        // then
+        verify(puppyRepository, never()).findAllByUserUserIdIn(anyList());
+        verify(drinkHistoryRepository, never()).countMonthlyDrinkByUserIds(anyList(), any(), any());
+    }
+
+    @Test
+    @DisplayName("음주 횟수가 목표보다 적으면 경험치 300을 지급한다")
+    void 음주_횟수가_목표_이하면_경험치_300이_지급된다() {
+        // given
+        Long userId = 1L;
+
+        UserGoalHistory goal = mock(UserGoalHistory.class);
+        when(goal.getUserId()).thenReturn(userId);
+        when(goal.getMonthlyGoalCount()).thenReturn(3);
+
+        Puppy puppy = mock(Puppy.class);
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppy.getUser()).thenReturn(user);
+        when(puppy.getPuppyExp()).thenReturn(100);
+
+        UserDrinkCountProjection stat = mock(UserDrinkCountProjection.class);
+        when(stat.getUserId()).thenReturn(userId);
+        when(stat.getTotalCount()).thenReturn(5L);
+        when(stat.getDrinkCount()).thenReturn(2L);
+
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of(goal));
+        when(puppyRepository.findAllByUserUserIdIn(anyList()))
+                .thenReturn(List.of(puppy));
+        when(drinkHistoryRepository.countMonthlyDrinkByUserIds(anyList(), any(), any()))
+                .thenReturn(List.of(stat));
+
+        // when
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        // then
+        verify(puppy).setPuppyExp(400);
+        verify(goal).markRewarded();
+    }
+
+    @Test
+    @DisplayName("음주 횟수가 목표를 초과하면 경험치를 지급하지 않는다")
+    void 음주_횟수가_목표_초과면_경험치가_지급되지_않는다() {
+        // given
+        Long userId = 1L;
+
+        UserGoalHistory goal = mock(UserGoalHistory.class);
+        when(goal.getUserId()).thenReturn(userId);
+        when(goal.getMonthlyGoalCount()).thenReturn(3);
+
+        Puppy puppy = mock(Puppy.class);
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppy.getUser()).thenReturn(user);
+
+        UserDrinkCountProjection stat = mock(UserDrinkCountProjection.class);
+        when(stat.getUserId()).thenReturn(userId);
+        when(stat.getTotalCount()).thenReturn(5L);
+        when(stat.getDrinkCount()).thenReturn(5L);
+
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of(goal));
+        when(puppyRepository.findAllByUserUserIdIn(anyList()))
+                .thenReturn(List.of(puppy));
+        when(drinkHistoryRepository.countMonthlyDrinkByUserIds(anyList(), any(), any()))
+                .thenReturn(List.of(stat));
+
+        // when
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        // then
+        verify(puppy, never()).setPuppyExp(anyInt());
+        verify(goal, never()).markRewarded();
+    }
+
+    @Test
+    @DisplayName("월간 기록이 아예 없는 유저는 경험치를 지급하지 않는다")
+    void 기록을_남기지_않은_유저는_경험치가_지급되지_않는다() {
+        Long userId = 1L;
+
+        UserGoalHistory goal = mock(UserGoalHistory.class);
+        when(goal.getUserId()).thenReturn(userId);
+
+        Puppy puppy = mock(Puppy.class);
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppy.getUser()).thenReturn(user);
+
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of(goal));
+        when(puppyRepository.findAllByUserUserIdIn(anyList()))
+                .thenReturn(List.of(puppy));
+        when(drinkHistoryRepository.countMonthlyDrinkByUserIds(anyList(), any(), any()))
+                .thenReturn(List.of());
+
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        verify(puppy, never()).setPuppyExp(anyInt());
+        verify(goal, never()).markRewarded();
+    }
+
+    @Test
+    @DisplayName("음주 횟수가 목표와 같으면 경험치 300을 지급한다")
+    void 음주_횟수가_목표와_같으면_경험치_300이_지급된다() {
+        // given
+        Long userId = 1L;
+
+        UserGoalHistory goal = mock(UserGoalHistory.class);
+        when(goal.getUserId()).thenReturn(userId);
+        when(goal.getMonthlyGoalCount()).thenReturn(3);
+
+        Puppy puppy = mock(Puppy.class);
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppy.getUser()).thenReturn(user);
+        when(puppy.getPuppyExp()).thenReturn(100);
+
+        UserDrinkCountProjection stat = mock(UserDrinkCountProjection.class);
+        when(stat.getUserId()).thenReturn(userId);
+        when(stat.getTotalCount()).thenReturn(3L);
+        when(stat.getDrinkCount()).thenReturn(3L);
+
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of(goal));
+        when(puppyRepository.findAllByUserUserIdIn(anyList()))
+                .thenReturn(List.of(puppy));
+        when(drinkHistoryRepository.countMonthlyDrinkByUserIds(anyList(), any(), any()))
+                .thenReturn(List.of(stat));
+
+        // when
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        // then
+        verify(puppy).setPuppyExp(400);
+        verify(goal).markRewarded();
+    }
+
+    @Test
+    @DisplayName("기록은 있지만 모두 '안 마셨어요'인 경우 경험치 300을 지급한다")
+    void 기록은_있는데_전부_안마신_유저는_경험치_300이_지급된다() {
+        // given
+        Long userId = 1L;
+
+        UserGoalHistory goal = mock(UserGoalHistory.class);
+        when(goal.getUserId()).thenReturn(userId);
+        when(goal.getMonthlyGoalCount()).thenReturn(3);
+
+        Puppy puppy = mock(Puppy.class);
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppy.getUser()).thenReturn(user);
+        when(puppy.getPuppyExp()).thenReturn(100);
+
+        UserDrinkCountProjection stat = mock(UserDrinkCountProjection.class);
+        when(stat.getUserId()).thenReturn(userId);
+        when(stat.getTotalCount()).thenReturn(5L);
+        when(stat.getDrinkCount()).thenReturn(0L);
+
+        when(userGoalHistoryRepository.findAllByGoalMonthAndRewardedFalse(any()))
+                .thenReturn(List.of(goal));
+        when(puppyRepository.findAllByUserUserIdIn(anyList()))
+                .thenReturn(List.of(puppy));
+        when(drinkHistoryRepository.countMonthlyDrinkByUserIds(anyList(), any(), any()))
+                .thenReturn(List.of(stat));
+
+        // when
+        monthlyGoalScheduler.evaluateMonthlyGoals();
+
+        // then
+        verify(puppy).setPuppyExp(400);
+        verify(goal).markRewarded();
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
월간 목표 달성 경험치 지급 기준 수정 및 월말 스케줄러 구현

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #148 

## 🔍 작업 내용  
- 버그 수정: isDrink=false(비음주일) → isDrink=true(실제 음주 횟수) 기준으로 변경
- 스케줄러 구현: MonthlyGoalScheduler.evaluateMonthlyGoals()로 월말 자동 집계/보상 지급
  - cron: `0 59 23 L * *` (매월 마지막 날 23:59, Asia/Seoul)
  - 로직: `drinkCount <= monthlyGoalCount` 조건으로 Puppy 경험치 +300 지급
- 단위 테스트
   1. 목표 없음 → 스킵
   2. 음주 2회 < 목표 3회 → 보상 O  
   3. 음주 5회 > 목표 3회 → 보상 X
   4. 기록 없음 → 보상 X
   5. 음주 3회 = 목표 3회 → 보상 O
   6. 기록 5건 전부 "안 마셨어요" → 보상 O (0 <= 3)

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * 매월 말일에 월간 음주 목표 달성 여부를 자동으로 평가하고, 목표 달성 시 펫 경험치 리워드를 자동으로 지급합니다.
  * 음주 기록 저장 시 일정한 경험치를 부여하는 기능이 개선되었습니다.

* **테스트**
  * 월별 목표 평가 로직에 대한 테스트 커버리지를 추가하였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->