### PR TITLE
[FIX] FCM 서비스 계정 키 Base64 인코딩 방식으로 변경 #150

### DIFF
--- a/src/main/java/com/umc/puppymode2/global/config/FcmConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/FcmConfig.java
@@ -10,28 +10,29 @@ import org.springframework.context.annotation.Configuration;
 
 import java.io.ByteArrayInputStream;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 
 @Slf4j
 @Configuration
 public class FcmConfig {
 
-    @Value("${firebase.credentials-json:}")
-    private String credentialsJson;
+    @Value("${firebase.credentials-base64:}")
+    private String credentialsBase64;
 
     @PostConstruct
     public void initFirebase() {
         if (!FirebaseApp.getApps().isEmpty()) return;
 
-        if (credentialsJson == null || credentialsJson.isBlank()) {
+        if (credentialsBase64 == null || credentialsBase64.isBlank()) {
             log.warn("[FCM] 서비스 계정 키 없음. 초기화 스킵");
             return;
         }
 
         try {
+            byte[] decoded = Base64.getDecoder().decode(credentialsBase64);
             GoogleCredentials credentials = GoogleCredentials.fromStream(
-                    new ByteArrayInputStream(credentialsJson.getBytes(StandardCharsets.UTF_8))
+                    new ByteArrayInputStream(decoded)
             );
-
             FirebaseApp.initializeApp(FirebaseOptions.builder()
                     .setCredentials(credentials)
                     .build());


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
FCM 서비스 계정 키 YAML 파싱 오류 수정

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #

## 🔍 작업 내용  
- FCM 서비스 계정 키를 Base64 인코딩 방식으로 변경
- YAML 파싱 시 private_key 개행문자로 인한 MalformedJsonException 해결
- FcmConfig에서 Base64 디코딩 후 Firebase 초기화하도록 수정

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기타(Chores)**
  * Firebase 구성 처리 방식이 개선되었습니다.

**사용자 영향**: 없음

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NEW-PuppyMode/PuppyMode-Server/pull/154)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->