### PR TITLE
[FEAT] 앱 버전 조회 API 업데이트 필요 여부 판단 로직 추가 #156

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/version/controller/VersionController.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/controller/VersionController.java
@@ -3,13 +3,15 @@ package com.umc.puppymode2.domain.version.controller;
 import com.umc.puppymode2.domain.version.dto.VersionResponseDto;
 import com.umc.puppymode2.domain.version.service.VersionQueryService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "version-controller", description = "앱 버전 조회 API")
 @RestController
 @RequestMapping("/version")
 @RequiredArgsConstructor
@@ -18,31 +20,24 @@ public class VersionController {
     private final VersionQueryService versionQueryService;
 
     @Operation(
-            summary = "앱 최신 버전 조회",
-            description = "현재 앱의 최신 버전 정보를 조회합니다."
+            summary = "앱 버전 업데이트 여부 조회",
+            description = "현재 앱 버전을 전달하면 강제/선택 업데이트 여부를 반환합니다.\n\n" +
+                    "- updateRequired: true → 강제 업데이트 (최소 요구 버전 미만)\n" +
+                    "- updateAvailable: true → 선택 업데이트 (최신 버전 존재)\n" +
+                    "- 둘 다 false → 최신 버전"
     )
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "버전 정보 조회 성공"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "400",
-                    description = "지원하지 않는 OS 타입"
-            ),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "500",
-                    description = "서버 오류"
-            )
-    })
     @GetMapping("/check")
     public ResponseEntity<ApiResponse<VersionResponseDto>> checkVersion(
             @Parameter(description = "OS 타입 (Android 또는 iOS)", example = "Android")
-            @RequestParam(defaultValue = "Android") String osType) {
+            @RequestParam(defaultValue = "Android") String osType,
+            @Parameter(description = "현재 앱 버전", example = "1.0.0")
+            @RequestParam String currentVersion) {
 
-        VersionResponseDto response = versionQueryService.getVersionInfo(osType);
+        VersionResponseDto response = versionQueryService.getVersionInfo(osType, currentVersion);
         return ResponseEntity.ok(
-                ApiResponse.onSuccess(response, "GET_VERSION_INFO", "버전 정보 조회 성공")
+                ApiResponse.onSuccess(response,
+                        SuccessStatus.VERSION_CHECK_SUCCESS.getCode(),
+                        SuccessStatus.VERSION_CHECK_SUCCESS.getMessage())
         );
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/version/dto/VersionResponseDto.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/dto/VersionResponseDto.java
@@ -10,4 +10,6 @@ import lombok.Getter;
 public class VersionResponseDto {
     private String latestVersion;
     private String updateUrl;
+    private boolean updateRequired;
+    private boolean updateAvailable;
 }

--- a/src/main/java/com/umc/puppymode2/domain/version/entity/AppVersion.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/entity/AppVersion.java
@@ -21,14 +21,19 @@ public class AppVersion extends BaseEntity {
     @Column(nullable = false)
     private String latestVersion;
 
+    @Column(nullable = false)
+    private String minVersion;
+
     private String updateUrl;
 
     @Builder
     public AppVersion(String osType,
                       String latestVersion,
+                      String minVersion,
                       String updateUrl) {
         this.osType = osType;
         this.latestVersion = latestVersion;
+        this.minVersion = minVersion;
         this.updateUrl = updateUrl;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryService.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryService.java
@@ -3,5 +3,5 @@ package com.umc.puppymode2.domain.version.service;
 import com.umc.puppymode2.domain.version.dto.VersionResponseDto;
 
 public interface VersionQueryService {
-    VersionResponseDto getVersionInfo(String osType);
+    VersionResponseDto getVersionInfo(String osType, String currentVersion);
 }

--- a/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.umc.puppymode2.domain.version.service;
 import com.umc.puppymode2.domain.version.dto.VersionResponseDto;
 import com.umc.puppymode2.domain.version.entity.AppVersion;
 import com.umc.puppymode2.domain.version.repository.AppVersionRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -17,13 +19,33 @@ public class VersionQueryServiceImpl implements VersionQueryService {
 
     @Override
     @Transactional(readOnly = true)
-    public VersionResponseDto getVersionInfo(String osType) {
+    public VersionResponseDto getVersionInfo(String osType,  String currentVersion) {
         AppVersion appVersion = appVersionRepository.findByOsType(osType)
-                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OS 타입입니다."));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.UNSUPPORTED_OS_TYPE));
+
+        boolean updateRequired = isLowerVersion(currentVersion, appVersion.getMinVersion());
+        boolean updateAvailable = isLowerVersion(currentVersion, appVersion.getLatestVersion());
 
         return VersionResponseDto.builder()
                 .latestVersion(appVersion.getLatestVersion())
                 .updateUrl(appVersion.getUpdateUrl())
+                .updateRequired(updateRequired)
+                .updateAvailable(updateAvailable)
                 .build();
+    }
+
+    private boolean isLowerVersion(String current, String target) {
+        String[] currentParts = current.split("\\.");
+        String[] targetParts = target.split("\\.");
+
+        for (int i = 0; i < Math.max(currentParts.length, targetParts.length); i++) {
+            int c = i < currentParts.length ? Integer.parseInt(currentParts[i]) : 0;
+            int t = i < targetParts.length ? Integer.parseInt(targetParts[i]) : 0;
+
+            if (c < t) return true;
+            if (c > t) return false;
+        }
+
+        return false;
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/version/service/VersionQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.version.entity.AppVersion;
 import com.umc.puppymode2.domain.version.repository.AppVersionRepository;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.exception.GeneralException;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,7 +35,13 @@ public class VersionQueryServiceImpl implements VersionQueryService {
                 .build();
     }
 
+    private static final Pattern VERSION_PATTERN = Pattern.compile("^\\d+\\.\\d+\\.\\d+$");
+
     private boolean isLowerVersion(String current, String target) {
+        if (!VERSION_PATTERN.matcher(current).matches() || !VERSION_PATTERN.matcher(target).matches()) {
+            throw new GeneralException(ErrorStatus.INVALID_VERSION_FORMAT);
+        }
+
         String[] currentParts = current.split("\\.");
         String[] targetParts = target.split("\\.");
 

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -58,6 +58,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Redis 관련 에러
     REDIS_CONNECTION_FAILURE(HttpStatus.SERVICE_UNAVAILABLE, "REDIS5031", "Redis 서버에 연결할 수 없습니다. 잠시 후 다시 시도해주세요."),
+
+    // Version 관련 에러
+    UNSUPPORTED_OS_TYPE(HttpStatus.BAD_REQUEST, "VERSION4001", "지원하지 않는 OS 타입입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/ErrorStatus.java
@@ -61,6 +61,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // Version 관련 에러
     UNSUPPORTED_OS_TYPE(HttpStatus.BAD_REQUEST, "VERSION4001", "지원하지 않는 OS 타입입니다."),
+    INVALID_VERSION_FORMAT(HttpStatus.BAD_REQUEST, "VERSION4002", "올바르지 않은 버전 형식입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -39,7 +39,11 @@ public enum SuccessStatus implements BaseCode {
 
     // 알림 수신
     NOTIFICATION_STATUS_SUCCESS(HttpStatus.OK, "NOTIFICATION200", "알림 수신 여부 조회 성공"),
-    NOTIFICATION_UPDATE_SUCCESS(HttpStatus.OK, "NOTIFICATION201", "알림 수신 여부 변경 성공");
+    NOTIFICATION_UPDATE_SUCCESS(HttpStatus.OK, "NOTIFICATION201", "알림 수신 여부 변경 성공"),
+
+    // 버전
+    VERSION_CHECK_SUCCESS(HttpStatus.OK, "VERSION200", "버전 정보 조회 성공"),
+    ;
 
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
버전 조회 API에 현재 앱 버전 비교 로직을 추가해, 서버에서 강제/선택 업데이트 여부를 판단하도록 구조를 변경합니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #156 

## 🔍 작업 내용  
- 앱 버전 업데이트 여부 조회 API에 currentVersion 요청 파라미터 추가
- AppVersion 엔티티에 minVersion 필드 추가
- VersionResponseDto에 minVersion, updateRequired, updateAvailable 필드 추가
- 서버에서 버전 비교 로직 구현
- 강제 업데이트(minVersion 기준) 및 선택 업데이트(latestVersion 기준) 판단

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- currentVersion < minVersion → 강제 업데이트 (updateRequired = true)
- currentVersion < latestVersion → 선택 업데이트 (updateAvailable = true)
- 앱 신규 버전 배포 시 app_version 테이블의 latestVersion 및 minVersion 값을 직접 업데이트 필요
- 초기 데이터 iOS, Android 각각 DB에 삽입 필요!!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 버전 확인 API가 현재 버전 입력을 받아 업데이트 상태(필수/선택)를 반환하도록 개선되었습니다.
  * 응답에 "필수 업데이트"와 "업데이트 가능" 플래그가 추가되었습니다.

* **버그 수정 / 오류 처리**
  * 지원하지 않는 OS 타입 및 잘못된 버전 형식에 대해 명확한 오류 응답 및 메시지가 추가되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NEW-PuppyMode/PuppyMode-Server/pull/158)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->