### PR TITLE
[FEAT] 테스트용 음주 알림 즉시 발송 API 구현 #159

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/notification/controller/NotificationTestController.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/controller/NotificationTestController.java
@@ -1,0 +1,45 @@
+package com.umc.puppymode2.domain.notification.controller;
+
+import com.umc.puppymode2.domain.notification.dto.DrinkReminderTarget;
+import com.umc.puppymode2.domain.notification.repository.FcmTokenRepository;
+import com.umc.puppymode2.domain.notification.service.FcmSender;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Tag(name = "notification-test-controller", description = "알림 테스트 API")
+@RestController
+@RequestMapping("/notifications/test")
+@RequiredArgsConstructor
+public class NotificationTestController {
+
+    private final UserContext userContext;
+    private final FcmTokenRepository fcmTokenRepository;
+    private final FcmSender fcmSender;
+
+    @Operation(summary = "[테스트] 음주 알림 즉시 발송", description = "22시 스케줄러 대신 현재 유저에게 즉시 알림을 발송합니다.")
+    @PostMapping("/drink-reminder")
+    public ResponseEntity<ApiResponse<Void>> sendDrinkReminderNow() {
+        Long userId = userContext.getCurrentUserId();
+
+        List<DrinkReminderTarget> targets = fcmTokenRepository.findByUserUserId(userId)
+                .stream()
+                .map(token -> new DrinkReminderTarget(token.getFcmToken(), token.getUser().getUsername()))
+                .toList();
+
+        fcmSender.sendPersonalized(targets);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(
+                null,
+                SuccessStatus.NOTIFICATION_TEST_SEND_SUCCESS.getCode(),
+                SuccessStatus.NOTIFICATION_TEST_SEND_SUCCESS.getMessage()
+        ));
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/notification/repository/FcmTokenRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/repository/FcmTokenRepository.java
@@ -35,4 +35,6 @@ public interface FcmTokenRepository extends JpaRepository<FcmToken, Long> {
           )
         """)
     List<DrinkReminderTarget> findTargetsForDrinkReminder(@Param("today") LocalDate today);
+
+    List<FcmToken> findByUserUserId(Long userId);
 }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -40,6 +40,7 @@ public enum SuccessStatus implements BaseCode {
     // 알림 수신
     NOTIFICATION_STATUS_SUCCESS(HttpStatus.OK, "NOTIFICATION200", "알림 수신 여부 조회 성공"),
     NOTIFICATION_UPDATE_SUCCESS(HttpStatus.OK, "NOTIFICATION201", "알림 수신 여부 변경 성공"),
+    NOTIFICATION_TEST_SEND_SUCCESS(HttpStatus.OK, "NOTIFICATION202", "알림 발송 성공"),
 
     // 버전
     VERSION_CHECK_SUCCESS(HttpStatus.OK, "VERSION200", "버전 정보 조회 성공"),


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
테스트용 음주 알림 즉시 발송 API 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #159 

## 🔍 작업 내용  
- `POST /notifications/test/drink-reminder` 엔드포인트 추가
- `FcmTokenRepository.findByUserUserId()` 메서드 추가
- `SuccessStatus.NOTIFICATION_TEST_SEND_SUCCESS` 추가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [ ] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
테스트용 API로, 22시 스케줄러 동작과 무관하게 현재 유저에게 즉시 알림을 발송합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 음료수 알림 즉시 발송 테스트 기능이 추가되었습니다. 현재 로그인한 사용자의 기기로 테스트 알림을 발송할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->