### PR TITLE
[FEAT] 알림 스케줄러 및 FCM 발송 로그 추가 #161

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.notification.dto.DrinkReminderTarget;
 import com.umc.puppymode2.domain.notification.repository.FcmTokenRepository;
 import com.umc.puppymode2.domain.notification.service.FcmSender;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -12,6 +13,7 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class DrinkReminderScheduler {
@@ -22,11 +24,22 @@ public class DrinkReminderScheduler {
     // TODO: 멀티 인스턴스 배포 시 ShedLock 적용 필요
     @Scheduled(cron = "0 0 22 * * *", zone = "Asia/Seoul")
     public void sendDrinkReminder() {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        List<DrinkReminderTarget> targets = fcmTokenRepository.findTargetsForDrinkReminder(today);
+        try {
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            log.info("[DrinkReminder] 스케줄러 시작 - {}", today);
 
-        if (targets.isEmpty()) return;
+            List<DrinkReminderTarget> targets = fcmTokenRepository.findTargetsForDrinkReminder(today);
+            log.info("[DrinkReminder] 발송 대상: {}명", targets.size());
 
-        fcmSender.sendPersonalized(targets);
+            if (targets.isEmpty()) {
+                log.info("[DrinkReminder] 발송 대상 없음 - 종료");
+                return;
+            }
+
+            fcmSender.sendPersonalized(targets);
+            log.info("[DrinkReminder] 발송 완료");
+        } catch (Exception e) {
+            log.error("[DrinkReminder] 예외 발생", e);
+        }
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
@@ -29,6 +29,8 @@ public class FcmSender {
     public void sendPersonalized(List<DrinkReminderTarget> targets) {
         if (targets.isEmpty()) return;
 
+        log.info("[FCM] 전송 시작 - 총 {}명", targets.size());
+
         for (List<DrinkReminderTarget> batch : partition(targets, FCM_BATCH_SIZE)) {
             List<Message> messages = batch.stream()
                     .map(target -> Message.builder()
@@ -51,6 +53,9 @@ public class FcmSender {
 
             try {
                 BatchResponse response = FirebaseMessaging.getInstance().sendEach(messages);
+                log.info("[FCM] 배치 전송 완료 - 성공: {}, 실패: {}",
+                        response.getSuccessCount(), response.getFailureCount());
+
                 if (response.getFailureCount() > 0) {
                     handleFailures(batch, response);
                 }
@@ -65,8 +70,11 @@ public class FcmSender {
         for (int i = 0; i < responses.size(); i++) {
             if (!responses.get(i).isSuccessful()) {
                 MessagingErrorCode code = responses.get(i).getException().getMessagingErrorCode();
+                log.warn("[FCM] 토큰 전송 실패 - user: {}, errorCode: {}",
+                        targets.get(i).username(), code);
                 if (code == MessagingErrorCode.UNREGISTERED
                         || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                    log.warn("[FCM] 만료 토큰 삭제 - user: {}", targets.get(i).username());
                     fcmTokenRepository.deleteByFcmToken(targets.get(i).fcmToken());
                 }
             }


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
10시 스케줄 알림 미동작 원인 파악을 위한 로그 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #161 

## 🔍 작업 내용  
- DrinkReminderScheduler 실행 로그 및 예외 처리 추가
- FcmSender 배치 전송 성공/실패 로그 추가
- FcmSender 만료 토큰 삭제 로그 추가

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- 운영 환경에서 원인 파악 후 불필요한 로그 제거 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 변경 사항

* **개선 사항**
  * 알림 발송 시스템의 오류 처리 및 로깅을 강화했습니다.
  * 발송 과정의 각 단계(시작, 대상 수, 완료)에 대한 상세한 로그 기록이 추가되어 시스템 모니터링이 개선되었습니다.
  * 발송 실패 시 오류 추적이 향상되어 문제 해결이 더욱 용이해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->