### PR TITLE
Fix/#168 main utc kst timezone mismatch

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.advice.dto.AdviceResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,7 +36,7 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
 
     @Override
     public AdviceResponseDTO getAdvice(Long userId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(TimeConstants.KST);
         LocalDate firstDay = today.withDayOfMonth(1);
         LocalDate lastDay = today.withDayOfMonth(today.lengthOfMonth());
         LocalDate yesterday = today.minusDays(1);
@@ -114,9 +115,9 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
                     "자주 마시는 건\n괜찮은 게 아니라 익숙해진 거예요."
             ));
         }
-        
+
         // 한 달에 10회 이상
-        if(actual > 10) {
+        if (actual > 10) {
             messages.add("한 달 10회 이상은 위험선이에요.\n이번엔 줄여봐요.");
         }
 
@@ -125,14 +126,13 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
         return messages.get(random.nextInt(messages.size()));
     }
 
-    @Transactional
     private void saveAdviceRecord(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found for ID: " + userId));
 
         Advice advice = Advice.builder()
                 .user(user)
-                .advisedAt(LocalDateTime.now()) // 현재 시점 기록
+                .advisedAt(LocalDateTime.now(TimeConstants.KST)) // 현재 시점 기록 (KST)
                 .build();
 
         adviceRepository.save(advice);

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryQueryServiceImpl.java
@@ -3,6 +3,7 @@ package com.umc.puppymode2.domain.drinkhistory.service;
 import com.umc.puppymode2.domain.drinkhistory.converter.DrinkHistoryConverter;
 import com.umc.puppymode2.domain.drinkhistory.dto.DrinkHistoryStatusDTO;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +18,7 @@ public class DrinkHistoryQueryServiceImpl implements DrinkHistoryQueryService {
 
     @Override
     public DrinkHistoryStatusDTO getDrinkRecordStatus(Long userId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(TimeConstants.KST);
         LocalDate yesterday = today.minusDays(1);
 
         boolean hasToday = drinkHistoryRepository.existsByUserUserIdAndDrinkDate(userId, today);

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.hibernate.exception.ConstraintViolationException;
@@ -25,9 +26,9 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
     @Override
     public GoalPostResponseDTO postGoal(Long userId, GoalPostRequestDTO dto) {
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(TimeConstants.KST);
         LocalDate goalMonth = now.withDayOfMonth(1);
-        LocalDateTime goalSetAt = LocalDateTime.now();
+        LocalDateTime goalSetAt = LocalDateTime.now(TimeConstants.KST);
         int maxGoal = now.lengthOfMonth();
 
         try {

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImpl.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
 import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,7 +22,7 @@ public class UserGoalHistoryQueryServiceImpl implements UserGoalHistoryQueryServ
     @Override
     public GoalInfoResponseDTO getLatestGoal(Long userId) {
 
-        LocalDate now = LocalDate.now();
+        LocalDate now = LocalDate.now(TimeConstants.KST);
         LocalDate goalMonth = now.withDayOfMonth(1); // 이번 달 기준
 
         // 이번 달 목표 조회
@@ -46,7 +47,7 @@ public class UserGoalHistoryQueryServiceImpl implements UserGoalHistoryQueryServ
     @Override
     public boolean isMoreThan30DayPassed(Long userId) {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         // 이번 달 목표 존재 여부 확인
         return repository.findByUserIdAndGoalMonth(userId, goalMonth).isEmpty();

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -12,6 +12,7 @@ import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
 import com.umc.puppymode2.global.auth.context.UserContext;
 import com.umc.puppymode2.global.exception.GeneralException;
+import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -36,7 +37,7 @@ public class MainServiceImpl implements MainService {
 
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
-        
+
         Optional<Puppy> puppyOpt = puppyRepository.findByUser_UserId(userId);
 
         // 온보딩 미완료
@@ -58,13 +59,14 @@ public class MainServiceImpl implements MainService {
         boolean isPuppyName = puppy.isCustomName();
         boolean isMyName = user.isCustomName();
 
+        LocalDate today = LocalDate.now(TimeConstants.KST);
+
         boolean isGoal = userGoalHistoryRepository
                 .findTopByUserIdOrderByGoalSetAtDesc(userId)
-                .filter(h -> h.getGoalSetAt().getYear() == LocalDate.now().getYear()
-                        && h.getGoalSetAt().getMonthValue() == LocalDate.now().getMonthValue())
+                .filter(h -> h.getGoalSetAt().getYear() == today.getYear()
+                        && h.getGoalSetAt().getMonthValue() == today.getMonthValue())
                 .isPresent();
 
-        LocalDate today = LocalDate.now();
         LocalDate yesterday = today.minusDays(1);
         boolean didRecordYesterday = drinkHistoryRepository.existsByUserUserIdAndDrinkDate(userId, yesterday);
         boolean didRecordToday = drinkHistoryRepository.existsByUserUserIdAndDrinkDate(userId, today);

--- a/src/main/java/com/umc/puppymode2/global/util/TimeConstants.java
+++ b/src/main/java/com/umc/puppymode2/global/util/TimeConstants.java
@@ -1,0 +1,10 @@
+package com.umc.puppymode2.global.util;
+
+import java.time.ZoneId;
+
+public class TimeConstants {
+    public static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private TimeConstants() {
+    }
+}

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
 import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -40,7 +41,7 @@ class UserGoalHistoryCommandServiceImplTest {
                 .userId(userId)
                 .monthlyGoalCount(5)
                 .goalMonth(LocalDate.of(2025,3,1))
-                .goalSetAt(LocalDateTime.now())
+                .goalSetAt(LocalDateTime.now(TimeConstants.KST))
                 .build();
 
         when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
@@ -104,7 +105,7 @@ class UserGoalHistoryCommandServiceImplTest {
         UserGoalHistory lastGoal = UserGoalHistory.builder()
                 .monthlyGoalCount(3)
                 .goalMonth(LocalDate.of(2025,2,1))
-                .goalSetAt(LocalDateTime.now())
+                .goalSetAt(LocalDateTime.now(TimeConstants.KST))
                 .build();
 
         when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
@@ -139,7 +140,7 @@ class UserGoalHistoryCommandServiceImplTest {
         UserGoalHistory lastGoal = UserGoalHistory.builder()
                 .monthlyGoalCount(31)
                 .goalMonth(LocalDate.of(2025,1,1))
-                .goalSetAt(LocalDateTime.now())
+                .goalSetAt(LocalDateTime.now(TimeConstants.KST))
                 .build();
 
         when(repository.existsByUserIdAndGoalMonth(anyLong(), any()))
@@ -152,7 +153,7 @@ class UserGoalHistoryCommandServiceImplTest {
 
         verify(repository).saveAndFlush(argThat(goal ->
                 goal.getMonthlyGoalCount() ==
-                        Math.min(31, LocalDate.now().lengthOfMonth())
+                        Math.min(31, LocalDate.now(TimeConstants.KST).lengthOfMonth())
         ));
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryQueryServiceImplTest.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
 import com.umc.puppymode2.domain.goal.dto.GoalInfoResponseDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.util.TimeConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -38,13 +39,13 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 목표_조회_성공() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         UserGoalHistory goal = UserGoalHistory.builder()
                 .userId(userId)
                 .goalMonth(goalMonth)
                 .monthlyGoalCount(5)
-                .goalSetAt(LocalDateTime.now())
+                .goalSetAt(LocalDateTime.now(TimeConstants.KST))
                 .build();
 
         GoalInfoResponseDTO dto = GoalInfoResponseDTO.builder()
@@ -73,7 +74,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 목표가_없으면_null() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
                 .thenReturn(Optional.empty());
@@ -86,7 +87,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 이번달_목표_없으면_30일_지남_true() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         when(repository.findByUserIdAndGoalMonth(userId, goalMonth))
                 .thenReturn(Optional.empty());
@@ -97,7 +98,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 이번달_목표_있으면_false() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         UserGoalHistory goal = UserGoalHistory.builder()
                 .goalMonth(goalMonth)
@@ -112,7 +113,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 목표보다_실제_음주가_많으면_goalExceeded_true() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         UserGoalHistory goal = UserGoalHistory.builder()
                 .userId(userId)
@@ -138,7 +139,7 @@ class UserGoalHistoryQueryServiceImplTest {
     @Test
     void 목표와_실제_음주가_같으면_goalExceeded_true() {
 
-        LocalDate goalMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate goalMonth = LocalDate.now(TimeConstants.KST).withDayOfMonth(1);
 
         UserGoalHistory goal = UserGoalHistory.builder()
                 .userId(userId)


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
UTC/KST 타임존 불일치로 날짜가 잘못 계산되던 문제 수정

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #168 

## 🔍 작업 내용  
- KST 타임존 공통 상수(TimeConstants) 추가
- MainServiceImpl, DrinkHistoryQueryServiceImpl, UserGoalHistoryQueryServiceImpl, UserGoalHistoryCommandServiceImpl, AdviceQueryServiceImpl에서 LocalDate.now() / LocalDateTime.now() → KST 기준으로 수정
- 관련 테스트 코드(UserGoalHistoryQueryServiceImplTest, UserGoalHistoryCommandServiceImplTest) KST 기준으로 동기화

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- 서버가 UTC로 동작하여 LocalDate.now() 등이 타임존 미지정 시 KST 자정~오전 9시 사이 날짜를 하루 전으로 잘못 계산하던 문제
- DB에 이미 저장된 데이터는 변경하지 않으며, 이번 수정은 조회/신규 저장 시점의 날짜 계산 로직에만 적용됨

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 음주 기록, 조언, 목표 설정 및 메인 화면의 날짜·시간 기준을 한국 표준시(KST)로 통일했습니다.
  - 자정이나 월말·월초 경계에서 오늘/어제 기록, 이번 달 목표 여부, 목표 기간이 잘못 표시될 수 있는 문제를 개선했습니다.
  - 조언 기록의 저장 시각도 KST 기준으로 일관되게 기록됩니다.

- **테스트**
  - 목표 관련 기능의 날짜 계산 검증을 KST 기준에 맞게 보완했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->