### PR TITLE
[FEAT] iOS 알림 미수신 원인 파악용 FCM 발송 상세 로그 추가 #171

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
@@ -29,15 +29,16 @@ public class DrinkReminderScheduler {
             log.info("[DrinkReminder] 스케줄러 시작 - {}", today);
 
             List<DrinkReminderTarget> targets = fcmTokenRepository.findTargetsForDrinkReminder(today);
-            log.info("[DrinkReminder] 발송 대상: {}명", targets.size());
+            log.info("[DrinkReminder] 발송 대상: {}건", targets.size());
 
             if (targets.isEmpty()) {
                 log.info("[DrinkReminder] 발송 대상 없음 - 종료");
                 return;
             }
 
-            fcmSender.sendPersonalized(targets);
-            log.info("[DrinkReminder] 발송 완료");
+            FcmSender.FcmSendResult result = fcmSender.sendPersonalized(targets);
+            log.info("[DrinkReminder] 발송 처리 종료 - 성공: {}건, 실패: {}건",
+                    result.successCount(), result.failureCount());
         } catch (Exception e) {
             log.error("[DrinkReminder] 예외 발생", e);
         }

--- a/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/scheduler/DrinkReminderScheduler.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.notification.dto.DrinkReminderTarget;
 import com.umc.puppymode2.domain.notification.repository.FcmTokenRepository;
 import com.umc.puppymode2.domain.notification.service.FcmSender;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -11,8 +12,10 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
+// TODO: iOS 알림 미수신 원인 파악(#171) 완료 후, 아래 상세 로그 제거 필요
 public class DrinkReminderScheduler {
 
     private final FcmTokenRepository fcmTokenRepository;
@@ -21,11 +24,22 @@ public class DrinkReminderScheduler {
     // TODO: 멀티 인스턴스 배포 시 ShedLock 적용 필요
     @Scheduled(cron = "0 0 22 * * *", zone = "Asia/Seoul")
     public void sendDrinkReminder() {
-        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
-        List<DrinkReminderTarget> targets = fcmTokenRepository.findTargetsForDrinkReminder(today);
+        try {
+            LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+            log.info("[DrinkReminder] 스케줄러 시작 - {}", today);
 
-        if (targets.isEmpty()) return;
+            List<DrinkReminderTarget> targets = fcmTokenRepository.findTargetsForDrinkReminder(today);
+            log.info("[DrinkReminder] 발송 대상: {}명", targets.size());
 
-        fcmSender.sendPersonalized(targets);
+            if (targets.isEmpty()) {
+                log.info("[DrinkReminder] 발송 대상 없음 - 종료");
+                return;
+            }
+
+            fcmSender.sendPersonalized(targets);
+            log.info("[DrinkReminder] 발송 완료");
+        } catch (Exception e) {
+            log.error("[DrinkReminder] 예외 발생", e);
+        }
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
@@ -27,10 +27,13 @@ public class FcmSender {
      * sendEach 사용 → 메시지마다 내용이 달라도 한 번의 HTTP 요청으로 처리
      */
     @Transactional
-    public void sendPersonalized(List<DrinkReminderTarget> targets) {
-        if (targets.isEmpty()) return;
+    public FcmSendResult sendPersonalized(List<DrinkReminderTarget> targets) {
+        if (targets.isEmpty()) return new FcmSendResult(0, 0);
 
-        log.info("[FCM] 전송 시작 - 총 {}명", targets.size());
+        log.info("[FCM] 전송 시작 - 총 {}건", targets.size());
+
+        int totalSuccess = 0;
+        int totalFailure = 0;
 
         for (List<DrinkReminderTarget> batch : partition(targets, FCM_BATCH_SIZE)) {
             List<Message> messages = batch.stream()
@@ -57,6 +60,9 @@ public class FcmSender {
                 log.info("[FCM] 배치 전송 완료 - 성공: {}, 실패: {}",
                         response.getSuccessCount(), response.getFailureCount());
 
+                totalSuccess += response.getSuccessCount();
+                totalFailure += response.getFailureCount();
+
                 // 성공 건: messageId를 남겨야 Firebase/APNs 쪽에서 실제 도달 여부 추적 가능
                 List<SendResponse> responses = response.getResponses();
                 for (int i = 0; i < responses.size(); i++) {
@@ -71,8 +77,11 @@ public class FcmSender {
                 }
             } catch (FirebaseMessagingException e) {
                 log.error("[FCM] 배치 전송 실패", e);
+                totalFailure += batch.size();
             }
         }
+
+        return new FcmSendResult(totalSuccess, totalFailure);
     }
 
     private void handleFailures(List<DrinkReminderTarget> targets, BatchResponse response) {
@@ -91,10 +100,15 @@ public class FcmSender {
                     fcmTokenRepository.deleteByFcmToken(targets.get(i).fcmToken());
                 }
 
-                // APNs 인증 오류 (iOS 원인 파악용)
-                if (code == MessagingErrorCode.THIRD_PARTY_AUTH_ERROR
-                        || code == MessagingErrorCode.SENDER_ID_MISMATCH) {
-                    log.error("[FCM] APNs 인증 오류 의심 - user: {}, code: {} (Firebase 콘솔 APNs 인증키 확인 필요)",
+                // APNs 인증키 오류 (Firebase 콘솔 APNs 인증키 확인 필요)
+                if (code == MessagingErrorCode.THIRD_PARTY_AUTH_ERROR) {
+                    log.error("[FCM] APNs 인증 오류 - user: {}, code: {} (Firebase 콘솔 APNs 인증키 확인 필요)",
+                            maskUsername(targets.get(i).username()), code);
+                }
+
+                // sender ID 불일치 (다른 프로젝트에서 발급된 토큰일 가능성)
+                if (code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                    log.error("[FCM] Sender ID 불일치 - user: {}, code: {} (토큰 발급 프로젝트 확인 필요)",
                             maskUsername(targets.get(i).username()), code);
                 }
             }
@@ -120,4 +134,6 @@ public class FcmSender {
         }
         return partitions;
     }
+
+    public record FcmSendResult(int successCount, int failureCount) {}
 }

--- a/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
+++ b/src/main/java/com/umc/puppymode2/domain/notification/service/FcmSender.java
@@ -15,6 +15,7 @@ import java.util.List;
 @Slf4j
 @Component
 @RequiredArgsConstructor
+// TODO: iOS 알림 미수신 원인 파악(#171) 완료 후, 아래 상세 로그(log.info/warn/error) 및 maskUsername() 제거 필요
 public class FcmSender {
 
     private final FcmTokenRepository fcmTokenRepository;
@@ -28,6 +29,8 @@ public class FcmSender {
     @Transactional
     public void sendPersonalized(List<DrinkReminderTarget> targets) {
         if (targets.isEmpty()) return;
+
+        log.info("[FCM] 전송 시작 - 총 {}명", targets.size());
 
         for (List<DrinkReminderTarget> batch : partition(targets, FCM_BATCH_SIZE)) {
             List<Message> messages = batch.stream()
@@ -51,6 +54,18 @@ public class FcmSender {
 
             try {
                 BatchResponse response = FirebaseMessaging.getInstance().sendEach(messages);
+                log.info("[FCM] 배치 전송 완료 - 성공: {}, 실패: {}",
+                        response.getSuccessCount(), response.getFailureCount());
+
+                // 성공 건: messageId를 남겨야 Firebase/APNs 쪽에서 실제 도달 여부 추적 가능
+                List<SendResponse> responses = response.getResponses();
+                for (int i = 0; i < responses.size(); i++) {
+                    if (responses.get(i).isSuccessful()) {
+                        log.info("[FCM] 전송 성공 - user: {}, messageId: {}",
+                                maskUsername(batch.get(i).username()), responses.get(i).getMessageId());
+                    }
+                }
+
                 if (response.getFailureCount() > 0) {
                     handleFailures(batch, response);
                 }
@@ -64,13 +79,38 @@ public class FcmSender {
         List<SendResponse> responses = response.getResponses();
         for (int i = 0; i < responses.size(); i++) {
             if (!responses.get(i).isSuccessful()) {
-                MessagingErrorCode code = responses.get(i).getException().getMessagingErrorCode();
+                FirebaseMessagingException ex = responses.get(i).getException();
+                MessagingErrorCode code = ex.getMessagingErrorCode();
+
+                log.warn("[FCM] 토큰 전송 실패 - user: {}, errorCode: {}, message: {}",
+                        maskUsername(targets.get(i).username()), code, ex.getMessage());
+
                 if (code == MessagingErrorCode.UNREGISTERED
                         || code == MessagingErrorCode.INVALID_ARGUMENT) {
+                    log.warn("[FCM] 만료 토큰 삭제 - user: {}", maskUsername(targets.get(i).username()));
                     fcmTokenRepository.deleteByFcmToken(targets.get(i).fcmToken());
+                }
+
+                // APNs 인증 오류 (iOS 원인 파악용)
+                if (code == MessagingErrorCode.THIRD_PARTY_AUTH_ERROR
+                        || code == MessagingErrorCode.SENDER_ID_MISMATCH) {
+                    log.error("[FCM] APNs 인증 오류 의심 - user: {}, code: {} (Firebase 콘솔 APNs 인증키 확인 필요)",
+                            maskUsername(targets.get(i).username()), code);
                 }
             }
         }
+    }
+
+    // TODO: iOS 알림 미수신 원인 파악 완료 후 아래 로그 및 마스킹 로직 제거 (#171)
+    /**
+     * 운영 로그 - 실명/닉네임 마스킹
+     */
+    private String maskUsername(String username) {
+        if (username == null || username.isBlank()) return "unknown";
+        if (username.length() <= 2) {
+            return username.charAt(0) + "*";
+        }
+        return username.charAt(0) + "*".repeat(username.length() - 2) + username.charAt(username.length() - 1);
     }
 
     private <T> List<List<T>> partition(List<T> list, int size) {


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
iOS 알림 미수신 원인 파악을 위해 DrinkReminderScheduler 및 FcmSender에 상세 로그 추가

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #171 

## 🔍 작업 내용  
- DrinkReminderScheduler에 스케줄러 시작/발송 대상 수/발송 완료/예외 로그 추가
- FcmSender에 배치 전송 성공/실패 건수 로그 추가
- 전송 성공 시 messageId 로깅 (FCM/APNs 실제 도달 여부 추적용)
- 전송 실패 시 errorCode, 원문 메시지 로깅
- APNs 인증 오류(THIRD_PARTY_AUTH_ERROR, SENDER_ID_MISMATCH) 발생 시 별도 error 레벨로 강조 로깅 추가
- 로그에 남기는 username은 실명/닉네임 노출 방지를 위해 마스킹 처리

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 음료 알림 발송 과정의 진행 상태와 대상 수를 확인할 수 있도록 기록을 강화했습니다.
  * 알림 발송 중 오류가 발생해도 서비스가 중단되지 않도록 예외 처리를 개선했습니다.
  * 푸시 알림의 성공·실패 현황과 실패 원인을 더 명확히 확인할 수 있습니다.
  * 알림 발송 로그에 포함되는 사용자 정보는 마스킹되어 개인정보 노출을 줄였습니다.
  * 잘못된 토큰을 자동 정리하고, iOS 인증 관련 오류 식별 정보를 보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->