### PR TITLE
Bug/#173 exp percent level based

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -53,7 +53,7 @@ public class MainServiceImpl implements MainService {
         LevelExp levelInfo = levelExpRepository.findByExp(puppy.getPuppyExp())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LEVEL_NOT_FOUND));
         int currentLevel = levelInfo.getLevel();
-        int percent = calculateExp(puppy.getPuppyExp(), currentLevel);
+        int percent = calculateExp(puppy.getPuppyExp(), levelInfo);
         PuppyAppearance appearance = getAppearance(puppy.getPuppyType(), currentLevel);
 
         boolean isPuppyName = puppy.isCustomName();
@@ -86,16 +86,16 @@ public class MainServiceImpl implements MainService {
                 .build();
     }
 
-    // 외형 단계 내 진행도 퍼센트 계산
-    // Stage 1: exp 0~269 (레벨 1~9)
-    // Stage 2: exp 270~1044 (레벨 10~19)
-    // Stage 3: exp 1045~2044 (레벨 20~29)
+    // 레벨 단위 진행률 계산
+    // 현재 레벨의 minExp ~ maxExp 구간 기준
     // 레벨 30 도달 시 100% 고정
-    private int calculateExp(int exp, int currentLevel) {
-        if (currentLevel == 30) return 100;
-        int stageMinExp = currentLevel < 10 ? 0 : currentLevel < 20 ? 270 : 1045;
-        int stageMaxExp = currentLevel < 10 ? 270 : currentLevel < 20 ? 1045 : 2045;
-        double ratio = (double) (exp - stageMinExp) / (stageMaxExp - stageMinExp);
+    private int calculateExp(int exp, LevelExp levelInfo) {
+        if (levelInfo.getLevel() == 30) return 100;
+
+        int minExp = levelInfo.getMinExp();
+        int maxExp = levelInfo.getMaxExp();
+
+        double ratio = (double) (exp - minExp) / (maxExp - minExp);
         return (int) (ratio * 100);
     }
 

--- a/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
@@ -75,9 +75,10 @@ class MainServiceImplTest {
 
         LevelExp levelExp = mock(LevelExp.class);
         when(levelExp.getLevel()).thenReturn(1);
+        when(levelExp.getMinExp()).thenReturn(0);
+        when(levelExp.getMaxExp()).thenReturn(10);
 
         PuppyAppearance appearance = mock(PuppyAppearance.class);
-        when(appearance.getStage()).thenReturn(1);
         when(appearance.getStageName()).thenReturn("눈송이 비숑");
         when(appearance.getImageUrl()).thenReturn("url");
 
@@ -106,5 +107,183 @@ class MainServiceImplTest {
         // when & then
         assertThrows(GeneralException.class,
                 () -> mainService.getMainPageInfo());
+    }
+
+    @Test
+    void 구간_시작_exp면_퍼센트는_0이다() {
+        // given
+        User user = mock(User.class);
+
+        Puppy puppy = Puppy.builder()
+                .puppyType(PuppyType.BICHON)
+                .puppyExp(945) // Lv19 구간(945~1045) 시작점
+                .puppyName("테스트강아지")
+                .build();
+
+        LevelExp levelExp = mock(LevelExp.class);
+        when(levelExp.getLevel()).thenReturn(19);
+        when(levelExp.getMinExp()).thenReturn(945);
+        when(levelExp.getMaxExp()).thenReturn(1045);
+
+        PuppyAppearance appearance = mock(PuppyAppearance.class);
+        when(appearance.getStageName()).thenReturn("곱슬 푸들");
+        when(appearance.getImageUrl()).thenReturn("url");
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(levelExpRepository.findByExp(945)).thenReturn(Optional.of(levelExp));
+        when(puppyAppearanceRepository.findByPuppyTypeAndLevel(PuppyType.BICHON, 19))
+                .thenReturn(Optional.of(appearance));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertEquals(0, result.getPuppyLevelPercent());
+    }
+
+    @Test
+    void 구간_중간_exp면_퍼센트가_비율대로_계산된다() {
+        // given
+        User user = mock(User.class);
+
+        Puppy puppy = Puppy.builder()
+                .puppyType(PuppyType.BICHON)
+                .puppyExp(1010) // Lv19 구간(945~1045) 안, 65% 지점
+                .puppyName("테스트강아지")
+                .build();
+
+        LevelExp levelExp = mock(LevelExp.class);
+        when(levelExp.getLevel()).thenReturn(19);
+        when(levelExp.getMinExp()).thenReturn(945);
+        when(levelExp.getMaxExp()).thenReturn(1045);
+
+        PuppyAppearance appearance = mock(PuppyAppearance.class);
+        when(appearance.getStageName()).thenReturn("곱슬 푸들");
+        when(appearance.getImageUrl()).thenReturn("url");
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(levelExpRepository.findByExp(1010)).thenReturn(Optional.of(levelExp));
+        when(puppyAppearanceRepository.findByPuppyTypeAndLevel(PuppyType.BICHON, 19))
+                .thenReturn(Optional.of(appearance));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertEquals(65, result.getPuppyLevelPercent());
+    }
+
+    @Test
+    void 구간_끝_직전_exp면_퍼센트는_99이다() {
+        // given
+        User user = mock(User.class);
+
+        Puppy puppy = Puppy.builder()
+                .puppyType(PuppyType.BICHON)
+                .puppyExp(1044) // Lv19 구간(945~1045) 끝 직전
+                .puppyName("테스트강아지")
+                .build();
+
+        LevelExp levelExp = mock(LevelExp.class);
+        when(levelExp.getLevel()).thenReturn(19);
+        when(levelExp.getMinExp()).thenReturn(945);
+        when(levelExp.getMaxExp()).thenReturn(1045);
+
+        PuppyAppearance appearance = mock(PuppyAppearance.class);
+        when(appearance.getStageName()).thenReturn("곱슬 푸들");
+        when(appearance.getImageUrl()).thenReturn("url");
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(levelExpRepository.findByExp(1044)).thenReturn(Optional.of(levelExp));
+        when(puppyAppearanceRepository.findByPuppyTypeAndLevel(PuppyType.BICHON, 19))
+                .thenReturn(Optional.of(appearance));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertEquals(99, result.getPuppyLevelPercent());
+    }
+
+    @Test
+    void 레벨업하면_퍼센트가_0으로_초기화된다() {
+        // given
+        User user = mock(User.class);
+
+        Puppy puppy = Puppy.builder()
+                .puppyType(PuppyType.BICHON)
+                .puppyExp(1045) // Lv20 구간(1045~1145) 시작점으로 넘어감
+                .puppyName("테스트강아지")
+                .build();
+
+        LevelExp levelExp = mock(LevelExp.class);
+        when(levelExp.getLevel()).thenReturn(20);
+        when(levelExp.getMinExp()).thenReturn(1045);
+        when(levelExp.getMaxExp()).thenReturn(1145);
+
+        PuppyAppearance appearance = mock(PuppyAppearance.class);
+        when(appearance.getStageName()).thenReturn("악성 곱슬 푸들");
+        when(appearance.getImageUrl()).thenReturn("url");
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(levelExpRepository.findByExp(1045)).thenReturn(Optional.of(levelExp));
+        when(puppyAppearanceRepository.findByPuppyTypeAndLevel(PuppyType.BICHON, 20))
+                .thenReturn(Optional.of(appearance));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertEquals(0, result.getPuppyLevelPercent());
+    }
+
+    @Test
+    void 레벨30이면_퍼센트는_100이다() {
+        // given
+        User user = mock(User.class);
+
+        Puppy puppy = Puppy.builder()
+                .puppyType(PuppyType.BICHON)
+                .puppyExp(2045)
+                .puppyName("테스트강아지")
+                .build();
+
+        LevelExp levelExp = mock(LevelExp.class);
+        when(levelExp.getLevel()).thenReturn(30);
+
+        PuppyAppearance appearance = mock(PuppyAppearance.class);
+        when(appearance.getStageName()).thenReturn("최종 형태");
+        when(appearance.getImageUrl()).thenReturn("url");
+
+        when(userContext.getCurrentUserId()).thenReturn(userId);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(levelExpRepository.findByExp(2045)).thenReturn(Optional.of(levelExp));
+        when(puppyAppearanceRepository.findByPuppyTypeAndLevel(PuppyType.BICHON, 30))
+                .thenReturn(Optional.of(appearance));
+        when(userGoalHistoryRepository.findTopByUserIdOrderByGoalSetAtDesc(userId))
+                .thenReturn(Optional.empty());
+
+        // when
+        MainResponseDto result = mainService.getMainPageInfo();
+
+        // then
+        assertEquals(100, result.getPuppyLevelPercent());
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
@@ -76,7 +76,7 @@ class MainServiceImplTest {
         LevelExp levelExp = mock(LevelExp.class);
         when(levelExp.getLevel()).thenReturn(1);
         when(levelExp.getMinExp()).thenReturn(0);
-        when(levelExp.getMaxExp()).thenReturn(10);
+        when(levelExp.getMaxExp()).thenReturn(100);
 
         PuppyAppearance appearance = mock(PuppyAppearance.class);
         when(appearance.getStageName()).thenReturn("눈송이 비숑");


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
경험치 퍼센트 계산 기준을 스테이지 단위에서 레벨 단위로 수정

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #173 

## 🔍 작업 내용  
- MainServiceImpl.calculateExp() 계산 기준을 10레벨 스테이지 단위 → 레벨 1개 단위(minExp~maxExp)로 변경
- 레벨업마다 퍼센트가 0%로 리셋되도록 수정, Lv30 100% 고정 처리 유지
- 레벨 단위 계산 검증 테스트 추가 (구간 시작/중간/끝, 레벨업 리셋, Lv30 고정)

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 강아지 경험치 진행률이 현재 레벨의 경험치 구간을 기준으로 정확히 계산되도록 개선했습니다.
  * 최고 레벨에서는 경험치 진행률이 기존과 동일하게 100%로 표시됩니다.

* **테스트**
  * 레벨 시작·중간·끝 및 레벨업 직후, 최고 레벨의 경험치 표시를 검증하는 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->