### PR TITLE
Refactor/#170 onboarded field rename

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/dto/MainResponseDto.java
@@ -26,5 +26,8 @@ public class MainResponseDto {
     private boolean didRecordToday;  // 오늘 기록 완료 여부
 
     @JsonProperty("isOnboarded")
-    private boolean onboarded; // 온보딩 테스트 완료 여부
+    private boolean onboarded; // deprecated, isBreedTestDone 사용 예정
+
+    @JsonProperty("isBreedTestDone")
+    private boolean breedTestDone; // 강아지 유형 테스트 완료 여부
 }

--- a/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/service/MainServiceImpl.java
@@ -40,14 +40,15 @@ public class MainServiceImpl implements MainService {
 
         Optional<Puppy> puppyOpt = puppyRepository.findByUser_UserId(userId);
 
-        // 온보딩 미완료
+        // 강아지 유형 테스트 미완료
         if (puppyOpt.isEmpty()) {
             return MainResponseDto.builder()
                     .onboarded(false)
+                    .breedTestDone(false)
                     .build();
         }
 
-        // 온보딩 완료
+        // 강아지 유형 테스트 완료
         Puppy puppy = puppyOpt.get();
 
         LevelExp levelInfo = levelExpRepository.findByExp(puppy.getPuppyExp())
@@ -73,6 +74,7 @@ public class MainServiceImpl implements MainService {
 
         return MainResponseDto.builder()
                 .onboarded(true)
+                .breedTestDone(true)
                 .puppyLevel(currentLevel)
                 .puppyLevelName(appearance.getStageName())
                 .puppyLevelPercent(percent)

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
@@ -6,9 +6,15 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AuthMeResponseDTO(
 
         @Schema(
-                description = "온보딩 완료 여부",
+                description = "온보딩 완료 여부 (deprecated, isBreedTestDone 사용 예정)",
                 example = "true"
         )
-        boolean isOnboarded
+        boolean isOnboarded,
+
+        @Schema(
+                description = "강아지 유형 테스트 완료 여부",
+                example = "true"
+        )
+        boolean isBreedTestDone
 ) {
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -223,8 +223,8 @@ public class UserAuthServiceImpl implements UserAuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        boolean isOnboarded = puppyRepository.existsByUser_UserId(user.getUserId());
+        boolean isBreedTestDone = puppyRepository.existsByUser_UserId(user.getUserId());
 
-        return new AuthMeResponseDTO(isOnboarded);
+        return new AuthMeResponseDTO(isBreedTestDone, isBreedTestDone);
     }
 }

--- a/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/puppy/service/MainServiceImplTest.java
@@ -47,7 +47,7 @@ class MainServiceImplTest {
     private final Long userId = 1L;
 
     @Test
-    void 온보딩_미완료_유저가_메인을_조회하면_isOnboarded가_false이다() {
+    void 온보딩_미완료_유저가_메인을_조회하면_isOnboarded와_isBreedTestDone이_false이다() {
         // given
         User user = mock(User.class);
 
@@ -60,10 +60,11 @@ class MainServiceImplTest {
 
         // then
         assertFalse(result.isOnboarded());
+        assertFalse(result.isBreedTestDone());
     }
 
     @Test
-    void 온보딩_완료_유저가_메인을_조회하면_isOnboarded가_true이다() {
+    void 온보딩_완료_유저가_메인을_조회하면_isOnboarded와_isBreedTestDone이_true이다() {
         // given
         User user = mock(User.class);
 
@@ -96,6 +97,7 @@ class MainServiceImplTest {
 
         // then
         assertTrue(result.isOnboarded());
+        assertTrue(result.isBreedTestDone());
     }
 
     @Test


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
isOnboarded 필드명을 실제 의미에 맞게 isBreedTestDone으로 변경하려고 함

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #170 

## 🔍 작업 내용  
- isOnboarded가 실제 의미(강아지 유형 테스트 완료 여부)와 맞지 않아 isBreedTestDone으로 명칭 변경 진행
- 서버 필드 추가: AuthMeResponseDTO, MainResponseDto에 isBreedTestDone 필드 신규 추가 (isOnboarded는 삭제하지 않고 그대로 유지)
- 로직 반영: UserAuthServiceImpl.getAuthMe(), MainServiceImpl.getMainPageInfo()에서 기존과 동일한 puppy 존재 여부 판단 값을 신규 필드에도 함께 매핑

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- /auth/me가 AuthMeResponseDTO를 사용하고 있어서, 리뷰 요청 드립니다 @eldeoddt 
- DB 스키마 변경은 없습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 메인 화면과 내 정보에서 강아지 유형 테스트 완료 여부를 확인할 수 있습니다.
  * 강아지 등록 여부에 따라 유형 테스트 상태가 정확히 표시됩니다.

* **개선 사항**
  * 기존 온보딩 상태와 강아지 유형 테스트 상태를 구분해 제공합니다.
  * 관련 상태 표시 검증을 강화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->