### PR TITLE
[REFACTOR] 강아지/유저 이름 수정 API 컨벤션 정리 #176

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/puppy/controller/PuppyNameController.java
+++ b/src/main/java/com/umc/puppymode2/domain/puppy/controller/PuppyNameController.java
@@ -3,6 +3,7 @@ package com.umc.puppymode2.domain.puppy.controller;
 import com.umc.puppymode2.domain.puppy.dto.PuppyNameRequestDto;
 import com.umc.puppymode2.domain.puppy.service.PuppyNameService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,18 @@ public class PuppyNameController {
 
     private final PuppyNameService puppyNameService;
 
-    @PostMapping("/puppy-name")
-    @Operation(method = "POST", summary = "강아지 이름 짓기 API", description = "강아지의 이름을 등록하는 API입니다.")
+    @PatchMapping("/puppy-name")
+    @Operation(
+            method = "PATCH",
+            summary = "강아지 이름 수정 API",
+            description = "강아지의 이름을 수정하는 API입니다. (최초 설정 및 이후 이름 변경 시 공용으로 사용됩니다.) 최초 수정 시에만 경험치가 지급됩니다."
+    )
     public ApiResponse<Void> updatePuppyName(@Valid @RequestBody PuppyNameRequestDto requestDto) {
         puppyNameService.updatePuppyName(requestDto);
-        return ApiResponse.onSuccess(null, "POST_PUPPY_NAME_SUCCESS", "강아지 이름 지어주기 성공");
+        return ApiResponse.onSuccess(
+                null,
+                SuccessStatus.PUPPY_NAME_UPDATE_SUCCESS.getCode(),
+                SuccessStatus.PUPPY_NAME_UPDATE_SUCCESS.getMessage()
+        );
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/controller/UserNameController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/controller/UserNameController.java
@@ -3,6 +3,7 @@ package com.umc.puppymode2.domain.user.controller;
 import com.umc.puppymode2.domain.user.dto.UserNameUpdateRequestDto;
 import com.umc.puppymode2.domain.user.service.UserNameService;
 import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +15,18 @@ public class UserNameController {
 
     private final UserNameService userNameService;
 
-    @PostMapping("/my-name")
-    @Operation(method = "POST", summary = "내 이름 알려주기 API", description = "사용자의 이름을 등록하는 API입니다.")
-    public ApiResponse<Void> updateUsername(@RequestBody @Valid UserNameUpdateRequestDto requestDto) {
+    @PatchMapping("/user-name")
+    @Operation(
+            method = "PATCH",
+            summary = "유저 이름 수정 API",
+            description = "유저의 이름을 수정하는 API입니다. (최초 설정 및 이후 이름 변경 시 공용으로 사용됩니다.) 최초 수정 시에만 경험치가 지급됩니다."
+    )
+    public ApiResponse<Void> updateUsername(@Valid @RequestBody UserNameUpdateRequestDto requestDto) {
         userNameService.updateUsername(requestDto);
-        return ApiResponse.onSuccess(null, "POST_MY_NAME_SUCCESS", "내 이름 알려주기 성공");
+        return ApiResponse.onSuccess(
+                null,
+                SuccessStatus.USER_NAME_UPDATE_SUCCESS.getCode(),
+                SuccessStatus.USER_NAME_UPDATE_SUCCESS.getMessage()
+        );
     }
 }

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -21,6 +21,9 @@ public enum SuccessStatus implements BaseCode {
     AUTH_WITHDRAW_SUCCESS(HttpStatus.OK, "AUTH_WITHDRAW200", "회원탈퇴 성공"),
     AUTH_ME_SUCCESS(HttpStatus.OK, "AUTH_ME200", "사용자 정보 조회 성공"),
 
+    // 유저
+    USER_NAME_UPDATE_SUCCESS(HttpStatus.OK, "USER200", "유저 이름 수정 성공"),
+
     // 음주 기록
     DRINK_HISTORY_RECORD_SUCCESS(HttpStatus.OK, "DRINK_HISTORY200", "음주 기록 성공"),
 
@@ -44,6 +47,9 @@ public enum SuccessStatus implements BaseCode {
 
     // 버전
     VERSION_CHECK_SUCCESS(HttpStatus.OK, "VERSION200", "버전 정보 조회 성공"),
+
+    // 강아지
+    PUPPY_NAME_UPDATE_SUCCESS(HttpStatus.OK, "PUPPY200", "강아지 이름 설정/변경 성공"),
     ;
 
 

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -49,7 +49,7 @@ public enum SuccessStatus implements BaseCode {
     VERSION_CHECK_SUCCESS(HttpStatus.OK, "VERSION200", "버전 정보 조회 성공"),
 
     // 강아지
-    PUPPY_NAME_UPDATE_SUCCESS(HttpStatus.OK, "PUPPY200", "강아지 이름 설정/변경 성공"),
+    PUPPY_NAME_UPDATE_SUCCESS(HttpStatus.OK, "PUPPY200", "강아지 이름 수정 성공"),
     ;
 
 


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
강아지/유저 이름 수정 API의 HTTP 메서드와 엔드포인트, 성공 응답 코드를 컨벤션에 맞게 정리합니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #176 

## 🔍 작업 내용  
- 유저 이름 수정 API: `POST /my-name` → `PATCH /user-name`으로 변경
- 강아지/유저 이름 수정 API의 성공 응답을 하드코딩 문자열 대신 `SuccessStatus` enum(`PUPPY_NAME_UPDATE_SUCCESS`, `USER_NAME_UPDATE_SUCCESS`)으로 교체
- API 명세서 최신화 (메서드, 경로, 응답 코드/메시지)

## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
