### PR TITLE
[REFACTOR] 음주 리포트 조회 cache-aside 적용 및 캐시 미작동 버그 수정 #180

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/advice/service/AdviceQueryServiceImpl.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.advice.dto.AdviceResponseDTO;
 import com.umc.puppymode2.domain.drinkhistory.repository.DrinkHistoryRepository;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ import jakarta.persistence.EntityNotFoundException;
 import java.time.LocalDateTime;
 
 import java.time.LocalDate;
+import java.time.YearMonth;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Random;
@@ -33,6 +35,7 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
 
     private final AdviceRepository adviceRepository;
     private final UserRepository userRepository;
+    private final DrinkReportCacheService reportCacheService;
 
     @Override
     public AdviceResponseDTO getAdvice(Long userId) {
@@ -130,11 +133,17 @@ public class AdviceQueryServiceImpl implements AdviceQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new EntityNotFoundException("User not found for ID: " + userId));
 
+        LocalDateTime advisedAt = LocalDateTime.now(TimeConstants.KST);
+
         Advice advice = Advice.builder()
                 .user(user)
-                .advisedAt(LocalDateTime.now(TimeConstants.KST)) // 현재 시점 기록 (KST)
+                .advisedAt(advisedAt) // 현재 시점 기록 (KST)
                 .build();
 
         adviceRepository.save(advice);
+
+        // 잔소리(advice) 기록이 늘어나면 리포트의 scoldedCount가 바뀌므로
+        // 이번 달(advisedAt은 항상 현재 시점) 캐시를 무효화한다.
+        reportCacheService.evict(userId, YearMonth.from(advisedAt));
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/drinkhistory/service/DrinkHistoryCommandServiceImpl.java
@@ -10,10 +10,13 @@ import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
 import com.umc.puppymode2.domain.user.entity.User;
 import com.umc.puppymode2.domain.user.repository.UserRepository;
 import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import com.umc.puppymode2.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
 
 @Service
 @Transactional
@@ -22,6 +25,7 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
     private final UserRepository userRepository;
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final PuppyRepository puppyRepository;
+    private final DrinkReportCacheService reportCacheService;
 
     @Override
     public DrinkHistoryResponseDTO recordDrink(Long userId, DrinkHistoryRequestDTO dto) {
@@ -38,6 +42,11 @@ public class DrinkHistoryCommandServiceImpl implements DrinkHistoryCommandServic
                 .orElseThrow(() -> new GeneralException(ErrorStatus.PUPPY_NOT_FOUND));
 
         puppy.setPuppyExp(puppy.getPuppyExp() + 10);
+
+        // 음주 기록이 바뀌면 해당 월 리포트(음주 횟수/일수)가 달라지므로
+        // 캐시된 리포트를 무효화한다. dto.getDrinkDate() 기준이라 과거 날짜를
+        // 백필해도 정확히 그 달의 캐시만 지워진다.
+        reportCacheService.evict(userId, YearMonth.from(dto.getDrinkDate()));
 
         return DrinkHistoryConverter.toResponseDTO(drinkHistory.getDrinkHistoryId(), puppy.getPuppyExp());
     }

--- a/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImpl.java
@@ -5,6 +5,7 @@ import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.dto.GoalPostResponseDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import com.umc.puppymode2.global.util.TimeConstants;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.YearMonth;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +23,7 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
 
     private final UserGoalHistoryRepository repository;
     private final UserGoalHistoryConverter converter;
+    private final DrinkReportCacheService reportCacheService;
 
     @Transactional
     @Override
@@ -52,6 +55,9 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
 
                 repository.saveAndFlush(newGoal);
 
+                // 이번 달 목표(goal)가 방금 바뀌었으므로, 캐시된 이번 달 리포트도 무효화
+                reportCacheService.evict(userId, YearMonth.from(goalMonth));
+
                 return GoalPostResponseDTO.builder()
                         .isSuccess(true)
                         .code("POST_GOAL_SUCCESS")
@@ -77,6 +83,9 @@ public class UserGoalHistoryCommandServiceImpl implements UserGoalHistoryCommand
                     .build();
 
             repository.saveAndFlush(copiedGoal);
+
+            // 기존 목표를 그대로 이어받았더라도 이번 달 목표 row가 새로 생긴 것이므로 동일하게 무효화
+            reportCacheService.evict(userId, YearMonth.from(goalMonth));
 
             return GoalPostResponseDTO.builder()
                     .isSuccess(true)

--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -6,8 +6,10 @@ import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.advice.repository.AdviceRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.math3.special.Beta;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +18,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.YearMonth;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class DrinkReportServiceImpl implements DrinkReportService {
@@ -30,10 +33,24 @@ public class DrinkReportServiceImpl implements DrinkReportService {
     private final DrinkHistoryRepository drinkHistoryRepository;
     private final AdviceRepository adviceRepository;
     private final DrinkReportConverter drinkReportConverter;
+    private final DrinkReportCacheService reportCacheService;
 
     @Transactional(Transactional.TxType.SUPPORTS)
     @Override
     public DrinkReportResponseDTO drinkReport(Long userId, YearMonth targetMonth) {
+
+        // 캐시 적용 전/후 응답속도를 비교 측정하기 위한 타이머 (성능 측정용, 기능 로직과 무관)
+        long start = System.nanoTime();
+
+        // 1) cache-aside 조회: Redis에 캐시된 리포트가 있으면 DB를 전혀 거치지 않고 바로 반환
+        DrinkReportResponseDTO cached = reportCacheService.get(userId, targetMonth);
+        if (cached != null) {
+            log.debug("[REPORT PERF] cache HIT userId={} month={} elapsedMs={}",
+                    userId, targetMonth, elapsedMs(start));
+            return cached;
+        }
+
+        // 2) 캐시 미스: 이하는 기존과 동일하게 goal/drinkHistory/advice를 조합해 직접 계산
 
         LocalDate startDate = targetMonth.atDay(1);
         LocalDate endDate = targetMonth.atEndOfMonth();
@@ -102,13 +119,28 @@ public class DrinkReportServiceImpl implements DrinkReportService {
                         endDateTime
                 );
 
-        return drinkReportConverter.toDto(
+        DrinkReportResponseDTO result = drinkReportConverter.toDto(
                 goal,
                 drinkRecordCount,
                 drinkDays,
                 achievementRate,
                 scoldedCount
         );
+
+        // 3) 다음 조회부터는 캐시로 응답할 수 있도록 계산 결과를 Redis에 적재
+        reportCacheService.put(userId, targetMonth, result);
+
+        log.debug("[REPORT PERF] cache MISS userId={} month={} elapsedMs={}",
+                userId, targetMonth, elapsedMs(start));
+
+        return result;
+    }
+
+    /**
+     * 성능 측정용 헬퍼. 나노초 타임스탬프를 밀리초(소수점 포함) 경과시간으로 변환한다.
+     */
+    private double elapsedMs(long startNanos) {
+        return (System.nanoTime() - startNanos) / 1_000_000.0;
     }
 
     /**

--- a/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
+++ b/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
@@ -6,6 +6,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 import java.time.Duration;
 import java.time.YearMonth;
@@ -69,7 +71,28 @@ public class DrinkReportCacheService {
         }
     }
 
+    /**
+     * (userId, 월) 캐시를 무효화한다.
+     *
+     * 호출 시점에 활성 트랜잭션이 있으면, 그 트랜잭션이 커밋된 이후에 실제 삭제를 수행하도록 미룬다.
+     * 커밋 전에 바로 지우면, 그 사이에 끼어든 다른 요청이 아직 커밋되지 않은(=변경 전) 데이터로
+     * 캐시를 다시 채워버릴 수 있고, 그 stale 값이 TTL(최대 1일)만큼 남아있게 된다.
+     * 활성 트랜잭션이 없으면(예: 트랜잭션 밖에서 호출) 지금처럼 즉시 삭제한다.
+     */
     public void evict(Long userId, YearMonth targetMonth) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    doEvict(userId, targetMonth);
+                }
+            });
+        } else {
+            doEvict(userId, targetMonth);
+        }
+    }
+
+    private void doEvict(Long userId, YearMonth targetMonth) {
         try {
             redisTemplate.delete(buildKey(userId, targetMonth));
         } catch (Exception e) {

--- a/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
+++ b/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
@@ -1,0 +1,83 @@
+package com.umc.puppymode2.global.cache;
+
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.time.YearMonth;
+
+/**
+ * 월간 음주 리포트(DrinkReportResponseDTO)에 대한 cache-aside 캐시.
+ *
+ * 리포트는 goal(목표), drinkHistory(음주 기록), advice(잔소리 기록) 세 도메인의 데이터를
+ * 조합해 매번 다시 계산하므로, 세 도메인 중 하나라도 쓰기가 발생하면 해당 (userId, 월) 캐시를
+ * 즉시 evict해야 한다. TTL은 그 evict를 놓쳤을 때를 대비한 최후의 안전장치이다.
+ *
+ * Redis 장애 시에는 캐시를 건너뛰고 DB 조회로 폴백한다(리포트 조회는 Redis 없이도 동작해야 함).
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DrinkReportCacheService {
+
+    private static final String KEY_PREFIX = "report:";
+    private static final Duration CURRENT_MONTH_TTL = Duration.ofMinutes(5);
+    private static final Duration PAST_MONTH_TTL = Duration.ofDays(1);
+
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    /**
+     * 성능 측정 baseline용 스위치.
+     * false로 두면 캐시를 완전히 우회해 매 요청이 DB로 직행한다.
+     * (같은 빌드에서 -Dreport.cache.enabled=false 또는
+     *  REPORT_CACHE_ENABLED=false 로 전/후 비교 가능)
+     */
+    @Value("${report.cache.enabled:true}")
+    private boolean cacheEnabled = true;
+
+    public DrinkReportResponseDTO get(Long userId, YearMonth targetMonth) {
+        if (!cacheEnabled) {
+            return null;
+        }
+        try {
+            Object cached = redisTemplate.opsForValue().get(buildKey(userId, targetMonth));
+            if (cached instanceof DrinkReportResponseDTO dto) {
+                return dto;
+            }
+            return null;
+        } catch (Exception e) {
+            log.warn("[REPORT CACHE] 조회 실패, DB로 폴백합니다: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    public void put(Long userId, YearMonth targetMonth, DrinkReportResponseDTO dto) {
+        if (!cacheEnabled) {
+            return;
+        }
+        try {
+            Duration ttl = targetMonth.equals(YearMonth.now())
+                    ? CURRENT_MONTH_TTL
+                    : PAST_MONTH_TTL;
+            redisTemplate.opsForValue().set(buildKey(userId, targetMonth), dto, ttl);
+        } catch (Exception e) {
+            log.warn("[REPORT CACHE] 저장 실패, 캐싱 없이 진행합니다: {}", e.getMessage());
+        }
+    }
+
+    public void evict(Long userId, YearMonth targetMonth) {
+        try {
+            redisTemplate.delete(buildKey(userId, targetMonth));
+        } catch (Exception e) {
+            log.warn("[REPORT CACHE] 무효화 실패: {}", e.getMessage());
+        }
+    }
+
+    private String buildKey(Long userId, YearMonth targetMonth) {
+        return KEY_PREFIX + userId + ":" + targetMonth;
+    }
+}

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -41,8 +41,16 @@ public class RedisConfig {
     @Value("${spring.data.redis.ssl.enabled:false}")
     private boolean sslEnabled;
 
+    // TCP 연결 자체를 맺는 데 걸리는 시간 제한. 연결 수립 단계라 다소 여유 있게 잡아도 된다.
     @Value("${spring.data.redis.timeout:10s}")
     private Duration timeout;
+
+    // 명령(GET/SET/DEL 등) 하나의 응답을 기다리는 시간 제한.
+    // connectTimeout과 값을 공유하면, Redis가 연결은 됐지만 응답이 없는 상태(네트워크 지연,
+    // GC 정지 등)일 때 캐시 조회 한 번이 수십 초간 요청 스레드를 붙잡아 서비스 전체 가용성을
+    // 떨어뜨릴 수 있다. 캐시는 "빨리 실패하고 DB로 폴백"하는 게 핵심이라 짧게 잡는다.
+    @Value("${spring.data.redis.command-timeout:500ms}")
+    private Duration commandTimeout;
 
     /**
      * RedisConnectionFactory 수동 설정
@@ -57,6 +65,7 @@ public class RedisConfig {
         log.info("[REDIS ENV] REDIS_PASSWORD={}", redisPassword != null && !redisPassword.isEmpty() ? "***SET***" : "***EMPTY***");
         log.info("[REDIS ENV] SSL_ENABLED={}", sslEnabled);
         log.info("[REDIS ENV] TIMEOUT={}", timeout);
+        log.info("[REDIS ENV] COMMAND_TIMEOUT={}", commandTimeout);
 
         // Redis 서버 설정
         RedisStandaloneConfiguration config = new RedisStandaloneConfiguration();
@@ -78,7 +87,7 @@ public class RedisConfig {
         // LettuceClientConfiguration 빌더
         LettuceClientConfiguration.LettuceClientConfigurationBuilder clientConfigBuilder =
                 LettuceClientConfiguration.builder()
-                        .commandTimeout(timeout)
+                        .commandTimeout(commandTimeout)
                         .clientOptions(clientOptions);
 
         // SSL 활성화 (AWS ElastiCache용)
@@ -93,8 +102,8 @@ public class RedisConfig {
 
         factory.setValidateConnection(false);
 
-        log.info("[REDIS CONFIG] Host={}, Port={}, SSL={}, Timeout={}",
-                maskHost(redisHost), redisPort, sslEnabled, timeout);
+        log.info("[REDIS CONFIG] Host={}, Port={}, SSL={}, ConnectTimeout={}, CommandTimeout={}",
+                maskHost(redisHost), redisPort, sslEnabled, timeout, commandTimeout);
 
         return factory;
     }

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -42,14 +42,17 @@ public class RedisConfig {
     private boolean sslEnabled;
 
     // TCP 연결 자체를 맺는 데 걸리는 시간 제한. 연결 수립 단계라 다소 여유 있게 잡아도 된다.
-    @Value("${spring.data.redis.timeout:10s}")
-    private Duration timeout;
+    @Value("${spring.data.redis.connect-timeout:10s}")
+    private Duration connectTimeout;
 
     // 명령(GET/SET/DEL 등) 하나의 응답을 기다리는 시간 제한.
-    // connectTimeout과 값을 공유하면, Redis가 연결은 됐지만 응답이 없는 상태(네트워크 지연,
-    // GC 정지 등)일 때 캐시 조회 한 번이 수십 초간 요청 스레드를 붙잡아 서비스 전체 가용성을
-    // 떨어뜨릴 수 있다. 캐시는 "빨리 실패하고 DB로 폴백"하는 게 핵심이라 짧게 잡는다.
-    @Value("${spring.data.redis.command-timeout:500ms}")
+    // Spring Boot 컨벤션대로 spring.data.redis.timeout을 그대로 명령 타임아웃에 쓴다.
+    // 이 프로퍼티를 새 이름으로 바꿔버리면, 배포 환경이 이미 spring.data.redis.timeout을
+    // 설정해뒀을 때 그 값이 조용히 무시되고 다른 의미(연결 타임아웃)로 바뀌어버린다.
+    // connectTimeout과 값을 공유하던 예전 방식은, Redis가 연결은 됐지만 응답이 없는
+    // 상태(네트워크 지연, GC 정지 등)일 때 캐시 조회 한 번이 수십 초간 요청 스레드를
+    // 붙잡아 서비스 전체 가용성을 떨어뜨릴 수 있어 분리했다.
+    @Value("${spring.data.redis.timeout:10s}")
     private Duration commandTimeout;
 
     /**
@@ -64,7 +67,7 @@ public class RedisConfig {
         log.info("[REDIS ENV] REDIS_PORT={}", redisPort);
         log.info("[REDIS ENV] REDIS_PASSWORD={}", redisPassword != null && !redisPassword.isEmpty() ? "***SET***" : "***EMPTY***");
         log.info("[REDIS ENV] SSL_ENABLED={}", sslEnabled);
-        log.info("[REDIS ENV] TIMEOUT={}", timeout);
+        log.info("[REDIS ENV] CONNECT_TIMEOUT={}", connectTimeout);
         log.info("[REDIS ENV] COMMAND_TIMEOUT={}", commandTimeout);
 
         // Redis 서버 설정
@@ -79,7 +82,7 @@ public class RedisConfig {
         // ClientOptions 생성
         ClientOptions clientOptions = ClientOptions.builder()
                 .socketOptions(SocketOptions.builder()
-                        .connectTimeout(timeout)
+                        .connectTimeout(connectTimeout)
                         .keepAlive(true)
                         .build())
                 .build();
@@ -103,7 +106,7 @@ public class RedisConfig {
         factory.setValidateConnection(false);
 
         log.info("[REDIS CONFIG] Host={}, Port={}, SSL={}, ConnectTimeout={}, CommandTimeout={}",
-                maskHost(redisHost), redisPort, sslEnabled, timeout, commandTimeout);
+                maskHost(redisHost), redisPort, sslEnabled, connectTimeout, commandTimeout);
 
         return factory;
     }

--- a/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
+++ b/src/main/java/com/umc/puppymode2/global/config/RedisConfig.java
@@ -1,6 +1,9 @@
 package com.umc.puppymode2.global.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import io.lettuce.core.ClientOptions;
 import io.lettuce.core.SocketOptions;
 import lombok.Getter;
@@ -112,8 +115,25 @@ public class RedisConfig {
         template.setHashKeySerializer(new StringRedisSerializer());
 
         // Value 직렬화
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
-        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer(objectMapper));
+        // API 응답용 objectMapper를 그대로 넘기면 캐시된 JSON에 타입 정보(@class)가 남지 않아,
+        // 조회 시 원래 DTO가 아닌 LinkedHashMap으로 역직렬화되어 캐시가 항상 미스로 처리되는 문제가 있었다.
+        // Redis 전용 복사본에만 다형적 타입 정보를 활성화해서 이 문제를 해결한다.
+        // (원본 objectMapper를 직접 수정하면 REST API 응답 JSON에도 @class가 섞여 나가게 되므로 복사본을 사용)
+        // allowIfSubType으로 우리 도메인 패키지만 역직렬화 대상으로 허용해,
+        // 캐시된 값이 조작되더라도 임의 클래스가 역직렬화되는 걸 막는다 (Jackson 다형적 역직렬화 취약점 대비).
+        ObjectMapper redisObjectMapper = objectMapper.copy();
+        PolymorphicTypeValidator typeValidator = BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.umc.puppymode2")
+                .build();
+        redisObjectMapper.activateDefaultTyping(
+                typeValidator,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer valueSerializer = new GenericJackson2JsonRedisSerializer(redisObjectMapper);
+        template.setValueSerializer(valueSerializer);
+        template.setHashValueSerializer(valueSerializer);
 
         template.afterPropertiesSet();
         return template;

--- a/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/goal/service/UserGoalHistoryCommandServiceImplTest.java
@@ -4,6 +4,7 @@ import com.umc.puppymode2.domain.goal.converter.UserGoalHistoryConverter;
 import com.umc.puppymode2.domain.goal.dto.GoalPostRequestDTO;
 import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import com.umc.puppymode2.global.util.TimeConstants;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,6 +27,9 @@ class UserGoalHistoryCommandServiceImplTest {
 
     @Mock
     private UserGoalHistoryConverter converter;
+
+    @Mock
+    private DrinkReportCacheService reportCacheService;
 
     @InjectMocks
     private UserGoalHistoryCommandServiceImpl service;

--- a/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
@@ -6,6 +6,7 @@ import com.umc.puppymode2.domain.goal.entity.UserGoalHistory;
 import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import com.umc.puppymode2.global.cache.DrinkReportCacheService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,6 +37,9 @@ class DrinkReportServiceImplTest {
 
     @Mock
     private DrinkReportConverter drinkReportConverter;
+
+    @Mock
+    private DrinkReportCacheService reportCacheService;
 
     @InjectMocks
     private DrinkReportServiceImpl drinkReportService;

--- a/src/test/java/com/umc/puppymode2/global/cache/DrinkReportCacheServiceTest.java
+++ b/src/test/java/com/umc/puppymode2/global/cache/DrinkReportCacheServiceTest.java
@@ -1,0 +1,71 @@
+package com.umc.puppymode2.global.cache;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionSynchronizationUtils;
+
+import java.time.YearMonth;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class DrinkReportCacheServiceTest {
+
+    @Mock
+    private RedisTemplate<String, Object> redisTemplate;
+
+    @InjectMocks
+    private DrinkReportCacheService cacheService;
+
+    private final Long userId = 1L;
+    private final YearMonth month = YearMonth.of(2025, 8);
+    private final String key = "report:1:2025-08";
+
+    @AfterEach
+    void clearSynchronization() {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.clearSynchronization();
+        }
+    }
+
+    @Test
+    void 활성_트랜잭션이_없으면_evict가_즉시_실행된다() {
+        cacheService.evict(userId, month);
+
+        verify(redisTemplate).delete(key);
+    }
+
+    @Test
+    void 트랜잭션이_커밋되면_evict가_실행된다() {
+        TransactionSynchronizationManager.initSynchronization();
+
+        cacheService.evict(userId, month);
+
+        // 커밋 전이므로 아직 삭제되면 안 됨
+        verify(redisTemplate, never()).delete(key);
+
+        TransactionSynchronizationUtils.triggerAfterCommit();
+
+        verify(redisTemplate).delete(key);
+    }
+
+    @Test
+    void 트랜잭션이_롤백되면_evict가_실행되지_않는다() {
+        TransactionSynchronizationManager.initSynchronization();
+
+        cacheService.evict(userId, month);
+
+        // afterCommit 없이 afterCompletion(ROLLED_BACK)만 호출되는 롤백 상황을 흉내낸다
+        TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
+
+        verify(redisTemplate, never()).delete(key);
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요
음주 리포트(`GET /report`) 조회에 Redis 기반 cache-aside를 적용해 DB 부하와 응답속도를 개선했습니다. 적용 전후 성능을 k6로 측정·비교했고, 그 과정에서 발견된 캐시 미작동 버그와 CodeRabbit 리뷰로 나온 가용성/정합성 이슈들도 같이 수정했습니다.

## 🔗 관련 이슈
Closes #180

## 🔍 작업 내용
- `DrinkReportCacheService` 추가 (get/put/evict, `report:{userId}:{yyyy-MM}` 키, 당월 TTL 5분 / 과거월 TTL 1일)
- `DrinkReportServiceImpl.drinkReport()`에 캐시 조회/적재 로직 연결
- 캐시 무효화 지점 3곳 연결 (음주 기록 저장 / 목표 설정·유지 / 조언(advice) 저장), 각각 실제로 영향받는 월 기준으로 정확히 evict되도록 처리
- Redis 장애 시 캐시를 건너뛰고 DB로 폴백 (fail-open)
- **[버그 수정]** 캐시가 실제로는 한 번도 HIT되지 않던 직렬화 문제 수정 — Redis 전용 ObjectMapper 복사본에만 타입 정보(`@class`) 활성화, 도메인 패키지 화이트리스트로 역직렬화 보안 이슈도 방어
- **[CodeRabbit 리뷰 반영]**
  - Redis 명령 타임아웃을 연결 타임아웃과 분리해, Redis 응답 지연 시 요청 스레드가 장시간 블로킹되어 서비스 전체 가용성이 떨어지는 문제 수정
  - 위 타임아웃 프로퍼티를 Spring Boot 컨벤션(`spring.data.redis.timeout`=명령, `spring.data.redis.connect-timeout`=연결)에 맞게 재정렬 — 배포 환경이 이미 설정해둔 값이 조용히 다른 의미로 바뀌는 걸 방지
  - 트랜잭션 커밋 전에 캐시를 evict해서, 그 사이 끼어든 조회가 stale 데이터로 캐시를 다시 채우는 레이스 수정 (커밋 이후로 evict 지연)
- k6 기반 부하테스트로 캐시 적용 전/후 응답속도·처리량 비교 측정 (일반 부하 avg 약 3.7배, 고부하 시 처리량 약 6배 개선)
- evict의 트랜잭션 커밋/롤백 시점 처리를 검증하는 유닛 테스트 추가


<p align="center">
<img width="596" height="165" alt="image" src="https://github.com/user-attachments/assets/c6b48145-217d-424c-9d7e-1280cab9923c" />

<img width="652" height="434" alt="image" src="https://github.com/user-attachments/assets/6f41b5cd-365f-47b9-baaf-8a2d9437d85e" />
</p>


## ✅ 체크리스트
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다. (curl 반복 요청 + 서버 로그로 cache HIT/MISS 직접 확인, 목표 변경 → evict → 재조회 사이클까지 검증)
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다. (Redis 장애 시 fail-open, 트랜잭션 롤백 시 evict 미실행 검증)
- [x] 관련 문서 및 API 명세를 최신 상태로 유지했습니다. (API 응답/요청 스펙 변경 없음)
- [x] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다. (신규 환경변수 없음, 기존 `spring.data.redis.timeout` 의미 유지
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks
# 🚀 PR 개요
음주 리포트(`GET /report`) 조회에 Redis 기반 cache-aside를 적용해 DB 부하와 응답속도를 개선하고, 적용 전후 성능을 k6로 측정·비교했습니다.

## 🔗 관련 이슈
Closes #180

## 🔍 작업 내용
- `DrinkReportCacheService` 추가 (get/put/evict, `report:{userId}:{yyyy-MM}` 키, 당월 TTL 5분 / 과거월 TTL 1일)
- `DrinkReportServiceImpl.drinkReport()`에 캐시 조회/적재 로직 연결
- 캐시 무효화 지점 3곳 연결 (음주 기록 저장 / 목표 설정·유지 / 조언(advice) 저장), 각각 실제로 영향받는 월 기준으로 정확히 evict되도록 처리
- Redis 장애 시 캐시를 건너뛰고 DB로 폴백 (fail-open)
- **[버그 수정]** 캐시가 실제로는 한 번도 HIT되지 않던 문제 발견 및 수정 — 자세한 내용은 아래 Remarks 참고
- k6 기반 부하테스트로 캐시 적용 전/후 응답속도·처리량 비교 측정

## ✅ 체크리스트
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다. (curl 반복 요청 + 서버 로그로 cache HIT/MISS 직접 확인)
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다. (Redis 장애 시 fail-open 동작 확인)
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다. (신규 환경변수 없음 — 해당 없음)
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks
- **개발 중 캐시가 한 번도 HIT되지 않는 버그를 발견해서 같이 수정했습니다.** `RedisConfig`가 API 응답용 `ObjectMapper`를 그대로 재사용해서, 캐시에 저장된 JSON에 타입 정보(`@class`)가 남지 않아 조회 시 원래 DTO가 아닌 `LinkedHashMap`으로 역직렬화되고, 그로 인해 `instanceof` 체크가 항상 실패해 매 요청이 조용히(예외 없이) MISS 처리되고 있었습니다.
- **CodeRabbit 리뷰에서 두 가지가 추가로 나와서 같이 반영했습니다.**
  1. Redis 명령 타임아웃이 연결 타임아웃과 같은 값을 쓰고 있어서, Redis가 응답 없는 상태가 되면 요청 스레드가 수십 초간 블로킹될 수 있었습니다 → 짧은 명령 타임아웃으로 분리했습니다.
  2. 3개 쓰기 경로 모두 트랜잭션 커밋 전에 캐시를 evict하고 있어서, 그 사이 끼어든 조회가 stale 데이터로 캐시를 다시 채울 수 있었습니다 → 커밋 이후로 evict를 지연하도록 수정했습니다.
- 리포트는 goal/drinkHistory/advice 세 도메인 데이터를 조합한 값이라, 세 쓰기 경로 중 하나라도 무효화를 놓치면 캐시 정합성이 깨집니다 → **무효화 지점 3곳(`DrinkHistoryCommandServiceImpl`, `UserGoalHistoryCommandServiceImpl`, `AdviceQueryServiceImpl`) 리뷰를 특히 신경써서 봐주세요.**
- 성능 측정 결과, 일반 부하(VUS=20)에서 avg 응답속도 약 3.7배, 고부하(VUS=150, DB 커넥션 풀 경합 상황)에서는 처리량이 약 6배 개선됐습니다. 측정 과정·원인 분석·재현 명령어는 로컬에 별도로 정리해뒀습니다 (레포에는 커밋하지 않음).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
  - 월간 음주 리포트 조회 결과를 캐시하여 반복 조회 속도를 개선했습니다.
  - 음주 기록, 조언, 목표 변경 시 관련 월간 리포트가 자동으로 최신화됩니다.
  - 과거 날짜의 기록을 추가하거나 수정해도 해당 월의 리포트가 정확히 갱신됩니다.

- **개선 사항**
  - 변경 사항은 저장이 완료된 후 리포트에 반영되어 데이터 일관성을 높였습니다.
  - 캐시를 사용할 수 없는 경우에도 기존 방식으로 리포트를 안전하게 조회합니다.
  - Redis 응답 처리를 개선해 캐시 관련 지연을 줄였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->