### PR TITLE
[FIX] 이번달/오늘 판단 시 서버 기본 타임존 의존 문제 수정 (#168 재발) #180

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImpl.java
@@ -7,6 +7,7 @@ import com.umc.puppymode2.domain.advice.repository.AdviceRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
 import com.umc.puppymode2.global.cache.DrinkReportCacheService;
+import com.umc.puppymode2.global.util.TimeConstants;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -198,7 +199,9 @@ public class DrinkReportServiceImpl implements DrinkReportService {
     }
 
     private int resolveCurrentDay(YearMonth targetMonth) {
-        LocalDate today = LocalDate.now();
+        // 서버 JVM 기본 타임존(운영은 보통 UTC)이 아니라 항상 KST 기준으로 "오늘"을 계산한다.
+        // 그렇지 않으면 한국 시간 00:00~08:59 사이에 날짜/월 계산이 하루 어긋난다 (#168과 동일 원인).
+        LocalDate today = LocalDate.now(TimeConstants.KST);
         YearMonth currentMonth = YearMonth.from(today);
 
         if (targetMonth.equals(currentMonth)) {

--- a/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
+++ b/src/main/java/com/umc/puppymode2/global/cache/DrinkReportCacheService.java
@@ -1,6 +1,7 @@
 package com.umc.puppymode2.global.cache;
 
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import com.umc.puppymode2.global.util.TimeConstants;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -62,7 +63,10 @@ public class DrinkReportCacheService {
             return;
         }
         try {
-            Duration ttl = targetMonth.equals(YearMonth.now())
+            // 서버 기본 타임존이 아니라 KST 기준으로 "이번 달"을 판단한다.
+            // 그렇지 않으면 매월 1일 새벽(KST 00:00~08:59) 동안 이번 달 리포트가
+            // 과거 달로 오인되어 TTL이 5분이 아니라 1일로 잘못 잡힌다 (#168과 동일 원인).
+            Duration ttl = targetMonth.equals(YearMonth.now(TimeConstants.KST))
                     ? CURRENT_MONTH_TTL
                     : PAST_MONTH_TTL;
             redisTemplate.opsForValue().set(buildKey(userId, targetMonth), dto, ttl);

--- a/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/report/service/DrinkReportServiceImplTest.java
@@ -7,11 +7,13 @@ import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
 import com.umc.puppymode2.domain.report.converter.DrinkReportConverter;
 import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
 import com.umc.puppymode2.global.cache.DrinkReportCacheService;
+import com.umc.puppymode2.global.util.TimeConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -355,6 +357,48 @@ class DrinkReportServiceImplTest {
                 eq(0),
                 eq(scoldedCount)
         );
+    }
+
+    /**
+     * #168과 동일한 원인의 회귀 테스트.
+     *
+     * resolveCurrentDay()가 LocalDate.now()를 타임존 없이 호출하면, 서버 JVM 기본 타임존이
+     * UTC일 때 한국 시간 00:00~08:59 사이에 날짜가 하루 어긋난다. 실제 벽시계 시각에
+     * 의존하면 이 버그는 하루 중 특정 시간대에만 재현되는 flaky한 테스트가 되므로,
+     * LocalDate.now(TimeConstants.KST) 호출 자체를 static mock으로 가로채 결정론적으로 검증한다.
+     */
+    @Test
+    void 이번달_리포트는_LocalDate_now_KST로_오늘_날짜를_계산한다() {
+        // given
+        YearMonth currentMonth = YearMonth.of(2025, 8);
+        LocalDate fixedToday = LocalDate.of(2025, 8, 20);
+
+        when(userGoalHistoryRepository
+                .findByUserIdAndGoalMonth(eq(userId), eq(currentMonth.atDay(1))))
+                .thenReturn(Optional.empty());
+        when(drinkHistoryRepository
+                .countByUserUserIdAndIsDrinkTrueAndDrinkDateBetween(eq(userId), any(), any()))
+                .thenReturn(0L);
+        when(drinkHistoryRepository
+                .countByUserUserIdAndDrinkDateBetween(eq(userId), any(), any()))
+                .thenReturn(0L);
+        when(adviceRepository
+                .countByUserUserIdAndAdvisedAtBetween(eq(userId), any(), any()))
+                .thenReturn(0L);
+        when(drinkReportConverter.toDto(anyInt(), anyLong(), anyLong(), anyInt(), anyInt()))
+                .thenReturn(mock(DrinkReportResponseDTO.class));
+
+        // when & then
+        try (MockedStatic<LocalDate> mockedLocalDate = mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+            mockedLocalDate.when(() -> LocalDate.now(TimeConstants.KST)).thenReturn(fixedToday);
+
+            drinkReportService.drinkReport(userId, currentMonth);
+
+            // KST를 명시한 오버로드가 실제로 호출됐는지
+            mockedLocalDate.verify(() -> LocalDate.now(TimeConstants.KST), atLeastOnce());
+            // 타임존 없는 오버로드(버그의 원인)는 절대 호출되면 안 됨
+            mockedLocalDate.verify(LocalDate::now, never());
+        }
     }
 
 }

--- a/src/test/java/com/umc/puppymode2/global/cache/DrinkReportCacheServiceTest.java
+++ b/src/test/java/com/umc/puppymode2/global/cache/DrinkReportCacheServiceTest.java
@@ -1,20 +1,25 @@
 package com.umc.puppymode2.global.cache;
 
+import com.umc.puppymode2.domain.report.dto.DrinkReportResponseDTO;
+import com.umc.puppymode2.global.util.TimeConstants;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.MockedStatic;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.support.TransactionSynchronizationUtils;
 
+import java.time.Duration;
 import java.time.YearMonth;
 
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class DrinkReportCacheServiceTest {
@@ -22,12 +27,20 @@ class DrinkReportCacheServiceTest {
     @Mock
     private RedisTemplate<String, Object> redisTemplate;
 
+    @Mock
+    private ValueOperations<String, Object> valueOperations;
+
     @InjectMocks
     private DrinkReportCacheService cacheService;
 
     private final Long userId = 1L;
     private final YearMonth month = YearMonth.of(2025, 8);
     private final String key = "report:1:2025-08";
+
+    @BeforeEach
+    void setUp() {
+        lenient().when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+    }
 
     @AfterEach
     void clearSynchronization() {
@@ -67,5 +80,46 @@ class DrinkReportCacheServiceTest {
         TransactionSynchronizationUtils.triggerAfterCompletion(TransactionSynchronization.STATUS_ROLLED_BACK);
 
         verify(redisTemplate, never()).delete(key);
+    }
+
+    /**
+     * #168과 동일한 원인의 회귀 테스트.
+     *
+     * put()의 TTL 분기가 YearMonth.now()를 타임존 없이 호출하면, 서버 JVM 기본 타임존이 UTC일 때
+     * 매월 1일 새벽(KST 00:00~08:59)에 "이번 달"이 "과거 달"로 오인되어 TTL이 5분이 아니라
+     * 1일로 잘못 잡힌다. 실제 벽시계 시각에 의존하면 하루 중 특정 시간대에만 재현되는
+     * flaky한 테스트가 되므로, YearMonth.now(TimeConstants.KST) 호출 자체를 static mock으로
+     * 가로채 결정론적으로 검증한다.
+     */
+    @Test
+    void 이번달이면_TTL_5분이_적용된다() {
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        try (MockedStatic<YearMonth> mockedYearMonth = mockStatic(YearMonth.class, CALLS_REAL_METHODS)) {
+            mockedYearMonth.when(() -> YearMonth.now(TimeConstants.KST)).thenReturn(month);
+
+            cacheService.put(userId, month, dto);
+
+            mockedYearMonth.verify(() -> YearMonth.now(TimeConstants.KST), atLeastOnce());
+            mockedYearMonth.verify(YearMonth::now, never());
+        }
+
+        verify(valueOperations).set(eq(key), eq(dto), eq(Duration.ofMinutes(5)));
+    }
+
+    @Test
+    void 과거달이면_TTL_1일이_적용된다() {
+        YearMonth currentMonth = YearMonth.of(2025, 9); // "지금"은 9월이라고 가정
+        DrinkReportResponseDTO dto = mock(DrinkReportResponseDTO.class);
+
+        try (MockedStatic<YearMonth> mockedYearMonth = mockStatic(YearMonth.class, CALLS_REAL_METHODS)) {
+            mockedYearMonth.when(() -> YearMonth.now(TimeConstants.KST)).thenReturn(currentMonth);
+
+            cacheService.put(userId, month, dto); // month = 2025-08, 즉 과거 달
+
+            mockedYearMonth.verify(() -> YearMonth.now(TimeConstants.KST), atLeastOnce());
+        }
+
+        verify(valueOperations).set(eq(key), eq(dto), eq(Duration.ofDays(1)));
     }
 }


### PR DESCRIPTION
# 🚀 PR 개요
음주 리포트 조회 시 "오늘 날짜"와 캐시 TTL의 "이번 달" 판단이 서버 JVM 기본 타임존에 의존하고 있어, 매일 새벽(KST 00:00~08:59) 시간대에 날짜/월 계산이 하루 어긋나던 문제를 수정했습니다 (#168과 동일한 원인의 재발 사례).

## 🔗 관련 이슈
Closes #180
Closes #168

## 🔍 작업 내용
- `DrinkReportServiceImpl.resolveCurrentDay()`의 `LocalDate.now()`가 타임존 미지정으로 서버 기본 타임존(UTC)을 따라, 매일 KST 00:00~08:59 사이에 날짜 계산이 하루 어긋나던 문제 수정 → `LocalDate.now(TimeConstants.KST)`로 명시
- `DrinkReportCacheService.put()`의 `YearMonth.now()`도 동일 원인으로, 매월 1일 새벽 이번 달 리포트가 과거 달로 오인되어 캐시 TTL이 5분이 아니라 1일로 잘못 적용되던 문제 수정 → `YearMonth.now(TimeConstants.KST)`로 명시
- 두 지점 모두 Mockito static mock으로 KST 오버로드 호출 여부를 결정론적으로 검증하는 회귀 테스트 추가 (실제 벽시계 시각에 의존하지 않도록 설계)

## ✅ 체크리스트
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다. (신규 테스트로 KST 기준 계산 검증)
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다. (수정 전 코드로 되돌려서 테스트가 실제로 실패하는지 확인 후 복원)
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다. (신규 환경변수 없음)
- [ ] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks
- `#168`에서 goal 관련 서비스들(`UserGoalHistoryCommandServiceImpl` 등)은 이미 `TimeConstants.KST`로 고쳐졌었는데, 이번에 리포트/캐시 쪽(`DrinkReportServiceImpl`, `DrinkReportCacheService`)에도 같은 패턴의 `LocalDate.now()`/`YearMonth.now()`가 남아있던 걸 발견해서 같이 고쳤습니다.
- 이 버그는 하루 중 특정 9시간 창(한국 새벽 시간대)에서만 재현되기 때문에, 일반적인 방식으로 테스트하면 실행 시점에 따라 통과/실패가 갈리는 flaky 테스트가 됩니다. 그래서 `Mockito.mockStatic`으로 `LocalDate.now(KST)`/`YearMonth.now(KST)` 호출 자체를 가로채서, 실행 시점과 무관하게 항상 같은 결과가 나오도록 테스트를 작성했습니다.
- 프로젝트 내에 이런 타임존 관련 버그가 앞으로 또 나올 수 있어서, `LocalDate.now()` / `LocalDateTime.now()` / `YearMonth.now()`를 타임존 없이 호출하는 곳이 남아있는지 전체적으로 한번 훑어보는 것도 제안드립니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 한국 표준시(KST) 기준으로 오늘 날짜와 월을 계산하도록 개선했습니다.
  * 매월 초 시간대에 음주 리포트 캐시 만료 시간이 잘못 설정되던 문제를 해결했습니다.
  * 현재 달 리포트에는 5분, 과거 달 리포트에는 1일의 만료 시간이 적용됩니다.

* **테스트**
  * KST 날짜 계산 및 캐시 만료 시간 적용에 대한 회귀 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->