### PR TITLE
Feat/#178 onboarding tutorial progress api

### DIFF
--- a/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
+++ b/src/main/java/com/umc/puppymode2/domain/goal/repository/UserGoalHistoryRepository.java
@@ -27,6 +27,8 @@ public interface UserGoalHistoryRepository extends JpaRepository<UserGoalHistory
     // 가장 최근 목표 조회 (기존 목표 유지 기능)
     Optional<UserGoalHistory> findTopByUserIdOrderByGoalMonthDesc(Long userId);
 
+    // 온보딩 최초 목표 설정 완료 여부 판단용 (월과 무관하게 이력이 하나라도 있는지)
+    boolean existsByUserId(Long userId);
 
     @Modifying
     @Query("DELETE FROM UserGoalHistory ugh WHERE ugh.userId = :userId")

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/progress/OnboardingProgressService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/progress/OnboardingProgressService.java
@@ -1,0 +1,46 @@
+package com.umc.puppymode2.domain.onboarding.progress;
+
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 온보딩(강아지 이름/ 내 이름 /최초 목표 설정) 완료 여부를 판단하는 서비스
+ *
+ * 별도의 진행 상태 컬럼을 두지 않고, 매 조회 시점에 실제 데이터
+ * (Puppy.isCustomName, User.isCustomName, UserGoalHistory 존재 여부)를 조합해 계산함.
+ * 각 단계 저장 API가 어떤 순서로 호출되든 항상 정확한 완료 여부 반환 가능
+ */
+@Service
+@RequiredArgsConstructor
+public class OnboardingProgressService {
+
+    private final PuppyRepository puppyRepository;
+    private final UserGoalHistoryRepository userGoalHistoryRepository;
+
+    /**
+     * 온보딩(강아지이름 + 내이름 + 최초 목표 설정) 완료 여부 계산
+     *
+     * 강아지 유형 검사(Puppy 생성) 자체는 판단 범위에 포함 x
+     * 검사 완료 여부는 기존 AuthMeResponseDTO.isOnboarded()로 별도 확인한다.
+     *
+     * @param user 조회 대상 유저
+     * @return 강아지 이름/ 내 이름/ 목표 3단계가 모두 완료됐으면 true
+     */
+    @Transactional(readOnly = true)
+    public boolean isOnboardingCompleted(User user) {
+        Puppy puppy = puppyRepository.findByUser_UserId(user.getUserId()).orElse(null);
+
+        if (puppy == null || !puppy.isCustomName()) {
+            return false;
+        }
+        if (!user.isCustomName()) {
+            return false;
+        }
+        return userGoalHistoryRepository.existsByUserId(user.getUserId());
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/controller/TutorialController.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/controller/TutorialController.java
@@ -1,0 +1,63 @@
+package com.umc.puppymode2.domain.onboarding.tutorial.controller;
+
+import com.umc.puppymode2.domain.onboarding.tutorial.service.TutorialService;
+import com.umc.puppymode2.global.apiPayload.ApiResponse;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.apiPayload.code.status.SuccessStatus;
+import com.umc.puppymode2.global.auth.context.UserContext;
+import com.umc.puppymode2.global.config.swagger.ApiErrorCodeExamples;
+import com.umc.puppymode2.global.config.swagger.ApiSuccessResponseExample;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/onboarding/tutorial")
+@Tag(name = "onboarding", description = "온보딩/튜토리얼 관련 API")
+public class TutorialController {
+
+    private final TutorialService tutorialService;
+    private final UserContext userContext;
+
+    /**
+     * 튜토리얼 진행 상태 등록
+     *
+     * 프론트에서 튜토리얼 화면 진입하는 시점에 호출
+     * 이후 유저가 끝까지 다 보든, 중간에 앱을 나가든 상관없이
+     * 다음 GET /auth/me 조회 시 tutorialShown이 true로
+     * 튜토리얼이 다시 노출되지 않음. (중도 이탈 = 자동 스킵)
+     */
+    @Operation(
+            summary = "튜토리얼 상태 등록",
+            description = """
+                    튜토리얼 화면 진입 시 호출하여 진행 상태를 '봤음'으로 등록.
+                    
+                    - 호출 시점: 튜토리얼 화면이 처음 렌더링될 때 (다 본 후 x)
+                    - 멱등성: 이미 등록된 상태에서 재호출해도 200 응답
+                    """
+    )
+    @PostMapping("/start")
+    @ApiSuccessResponseExample(
+            status = SuccessStatus.TUTORIAL_START_SUCCESS,
+            responseType = Void.class
+    )
+    @ApiErrorCodeExamples({
+            ErrorStatus.AUTH_INVALID_TOKEN,
+            ErrorStatus.USER_NOT_FOUND
+    })
+    public ApiResponse<Void> start() {
+        Long userId = userContext.getCurrentUserId();
+        tutorialService.markTutorialShown(userId);
+
+        return ApiResponse.onSuccess(
+                null,
+                SuccessStatus.TUTORIAL_START_SUCCESS.getCode(),
+                SuccessStatus.TUTORIAL_START_SUCCESS.getMessage()
+        );
+    }
+}
+

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialService.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialService.java
@@ -1,0 +1,16 @@
+package com.umc.puppymode2.domain.onboarding.tutorial.service;
+
+public interface TutorialService {
+
+    /**
+     * 튜토리얼 진행 상태를 "봤음"으로 등록
+     *
+     * 튜토리얼 화면 진입 시점에 호출하는 것을 전제로 함.
+     * 끝까지 다 보고 나가든, 중간에 이탈하든 결과(다음부터 튜토리얼 노출x)는
+     * 동일하므로 '완료'와 '이탈'을 구분해서 관리하지 않음.
+     * 이미 true인 상태에서 재호출해도 안전함
+     *
+     * @param userId 사용자 ID
+     */
+    void markTutorialShown(Long userId);
+}

--- a/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialServiceImpl.java
@@ -1,0 +1,28 @@
+package com.umc.puppymode2.domain.onboarding.tutorial.service;
+
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.apiPayload.code.status.ErrorStatus;
+import com.umc.puppymode2.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TutorialServiceImpl implements TutorialService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public void markTutorialShown(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 이미 true인 경우 재저장할 필요
+        if (!user.isTutorialShown()) {
+            user.setTutorialShown(true);
+        }
+    }
+}

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/controller/AuthController.java
@@ -177,7 +177,9 @@ public class AuthController {
             summary = "현재 사용자 상태 조회",
             description = """
                     현재 사용자의 상태를 조회합니다.
-                    - 온보딩 여부
+                    - isOnboarded / isPuppyTestCompleted: 강아지 유형 검사 완료 여부 (동일한 값, isOnboarded는 구버전 호환용)
+                    - onboardingCompleted: 강아지이름·내이름·최초 목표설정 완료 여부
+                    - tutorialShown: 튜토리얼 진행 여부
                     - 토큰이 유효하지 않은 경우 401 반환
                     """
     )

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/dto/AuthMeResponseDTO.java
@@ -6,9 +6,27 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record AuthMeResponseDTO(
 
         @Schema(
-                description = "온보딩 완료 여부",
+                description = "온보딩 완료 여부 (deprecated + 신규 개발 시에는 isPuppyTestCompledted)",
                 example = "true"
         )
-        boolean isOnboarded
+        boolean isOnboarded,
+
+        @Schema(
+                description = "강아지 유형 검사 완료 여부 (isOnboarded와 동일한 값)",
+                example = "true"
+        )
+        boolean isPuppyTestCompleted,
+
+        @Schema(
+                description = "온보딩(강아지 이름/내 이름/목표 설정) 완료 여부",
+                example = "false"
+        )
+        boolean onboardingCompleted,
+
+        @Schema(
+                description = "튜토리얼 진행 여부",
+                example = "false"
+        )
+        boolean tutorialShown
 ) {
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/auth/service/UserAuthServiceImpl.java
@@ -1,5 +1,6 @@
 package com.umc.puppymode2.domain.user.auth.service;
 
+import com.umc.puppymode2.domain.onboarding.progress.OnboardingProgressService;
 import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
 import com.umc.puppymode2.domain.user.auth.dto.AuthMeResponseDTO;
 import com.umc.puppymode2.domain.user.auth.dto.LoginResponseDTO;
@@ -39,6 +40,7 @@ public class UserAuthServiceImpl implements UserAuthService {
     private final SocialAuthRepository socialAuthRepository;
     private final RedisConfig.RedisHealthIndicator redisHealthIndicator;
     private final PuppyRepository puppyRepository;
+    private final OnboardingProgressService onboardingProgressService;
 
     @Transactional
     @Override
@@ -211,8 +213,11 @@ public class UserAuthServiceImpl implements UserAuthService {
     }
 
     /**
-     * 사용자의 온보딩 완료 여부를 조회합니다.
-     * - puppy 존재 여부를 기준으로 판단
+     * 사용자의 온보딩/튜토리얼 진행 상태를 조회합니다.
+     * - isOnboarded / isPuppyTestCompleted: puppy 존재 여부 (강아지 유형 검사 완료 여부)
+     *   ※ isOnboarded는 구버전 클라이언트 호환을 위해 유지, 값은 isPuppyTestCompleted와 동일
+     * - onboardingCompleted: 강아지이름 + 내이름 + 최초 목표설정 3단계 완료 여부
+     * - tutorialShown: 튜토리얼 노출 여부
      *
      * @param userId 사용자 ID
      * @return 사용자 상태 조회 응답 DTO
@@ -223,8 +228,14 @@ public class UserAuthServiceImpl implements UserAuthService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
 
-        boolean isOnboarded = puppyRepository.existsByUser_UserId(user.getUserId());
+        boolean isPuppyTestCompleted = puppyRepository.existsByUser_UserId(user.getUserId());
+        boolean onboardingCompleted = onboardingProgressService.isOnboardingCompleted(user);
 
-        return new AuthMeResponseDTO(isOnboarded);
+        return new AuthMeResponseDTO(
+                isPuppyTestCompleted,   // isOnboarded (구버전 호환, 값 동일)
+                isPuppyTestCompleted,   // isPuppyTestCompleted
+                onboardingCompleted,
+                user.isTutorialShown()
+        );
     }
 }

--- a/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
+++ b/src/main/java/com/umc/puppymode2/domain/user/entity/User.java
@@ -41,6 +41,9 @@ public class User extends BaseEntity {
     @Column(name = "is_custom_name", nullable = false)
     private boolean isCustomName = false;
 
+    @Column(nullable = false)
+    private boolean tutorialShown = false;
+
     private LocalDateTime withdrawnAt;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/com/umc/puppymode2/global/apiPayload/code/status/SuccessStatus.java
@@ -50,6 +50,9 @@ public enum SuccessStatus implements BaseCode {
 
     // 강아지
     PUPPY_NAME_UPDATE_SUCCESS(HttpStatus.OK, "PUPPY200", "강아지 이름 수정 성공"),
+
+    // 튜토리얼
+    TUTORIAL_START_SUCCESS(HttpStatus.OK, "TUTORIAL200", "튜토리얼 진행 상태 등록 성공"),
     ;
 
 

--- a/src/test/java/com/umc/puppymode2/domain/onboarding/progress/service/OnboardingProgressServiceTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/onboarding/progress/service/OnboardingProgressServiceTest.java
@@ -1,0 +1,141 @@
+package com.umc.puppymode2.domain.onboarding.progress.service;
+
+import com.umc.puppymode2.domain.goal.repository.UserGoalHistoryRepository;
+import com.umc.puppymode2.domain.onboarding.progress.OnboardingProgressService;
+import com.umc.puppymode2.domain.puppy.entity.Puppy;
+import com.umc.puppymode2.domain.puppy.repository.PuppyRepository;
+import com.umc.puppymode2.domain.user.entity.User;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OnboardingProgressServiceTest {
+
+    @Mock
+    private PuppyRepository puppyRepository;
+    @Mock
+    private UserGoalHistoryRepository userGoalHistoryRepository;
+
+    @InjectMocks
+    private OnboardingProgressService onboardingProgressService;
+
+    private final Long userId = 1L;
+
+    @Test
+    void 강아지_검사_자체를_안한_경우_온보딩_미완료다() {
+        // given
+        User user = mock(User.class);
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.empty());
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void 강아지_이름을_아직_안지은_경우_온보딩_미완료다() {
+        // given
+        User user = mock(User.class);
+        Puppy puppy = mock(Puppy.class);
+
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(puppy.isCustomName()).thenReturn(false);
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void 내이름을_아직_안지은_경우_온보딩_미완료다() {
+        // given
+        User user = mock(User.class);
+        Puppy puppy = mock(Puppy.class);
+
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(puppy.isCustomName()).thenReturn(true);
+        when(user.isCustomName()).thenReturn(false);
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void 목표_이력은_있지만_강아지이름_내이름을_아직_안지은_경우_온보딩_미완료다() {
+        // given
+        User user = mock(User.class);
+        Puppy puppy = mock(Puppy.class);
+
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(puppy.isCustomName()).thenReturn(false); // 강아지이름 아직
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertFalse(result);
+
+        verify(userGoalHistoryRepository, never()).existsByUserId(anyLong());
+    }
+
+    @Test
+    void 이름은_다_지었지만_목표_이력이_없는_경우_온보딩_미완료다() {
+        // given
+        User user = mock(User.class);
+        Puppy puppy = mock(Puppy.class);
+
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(puppy.isCustomName()).thenReturn(true);
+        when(user.isCustomName()).thenReturn(true);
+        when(userGoalHistoryRepository.existsByUserId(userId)).thenReturn(false);
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void 강아지이름_내이름_목표_모두_완료된_경우_온보딩_완료다() {
+        // given
+        User user = mock(User.class);
+        Puppy puppy = mock(Puppy.class);
+
+        when(user.getUserId()).thenReturn(userId);
+        when(puppyRepository.findByUser_UserId(userId)).thenReturn(Optional.of(puppy));
+        when(puppy.isCustomName()).thenReturn(true);
+        when(user.isCustomName()).thenReturn(true);
+        when(userGoalHistoryRepository.existsByUserId(userId)).thenReturn(true);
+
+        // when
+        boolean result = onboardingProgressService.isOnboardingCompleted(user);
+
+        // then
+        assertTrue(result);
+    }
+}

--- a/src/test/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialServiceImplTest.java
+++ b/src/test/java/com/umc/puppymode2/domain/onboarding/tutorial/service/TutorialServiceImplTest.java
@@ -1,0 +1,65 @@
+package com.umc.puppymode2.domain.onboarding.tutorial.service;
+
+import com.umc.puppymode2.domain.user.entity.User;
+import com.umc.puppymode2.domain.user.repository.UserRepository;
+import com.umc.puppymode2.global.exception.GeneralException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class TutorialServiceImplTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private TutorialServiceImpl tutorialService;
+
+    private final Long userId = 1L;
+
+    @Test
+    void 처음_호출하면_tutorialShown이_true로_설정된다() {
+        // given
+        User user = mock(User.class);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(user.isTutorialShown()).thenReturn(false);
+
+        // when
+        tutorialService.markTutorialShown(userId);
+
+        // then
+        verify(user).setTutorialShown(true);
+    }
+
+    @Test
+    void 이미_true인_상태에서_재호출해도_에러없이_통과한다() {
+        // given: 멱등성 확인 - 이미 봤음 상태에서 또 호출
+        User user = mock(User.class);
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(user.isTutorialShown()).thenReturn(true);
+
+        // when & then
+        assertDoesNotThrow(() -> tutorialService.markTutorialShown(userId));
+
+        // 이미 true이므로 불필요한 재저장 호출은 없어야 함
+        verify(user, never()).setTutorialShown(anyBoolean());
+    }
+
+    @Test
+    void 존재하지_않는_유저면_예외가_발생한다() {
+        // given
+        when(userRepository.findById(userId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThrows(GeneralException.class,
+                () -> tutorialService.markTutorialShown(userId));
+    }
+}


### PR DESCRIPTION
# 🚀 PR 개요  
<!-- 이번 PR에서 작업한 내용을 한 줄로 간단히 요약 -->
앱 진입 시 온보딩(강아지이름/내이름/목표설정)·튜토리얼 진행 상태를 조회하는 API를 구현합니다.

## 🔗 관련 이슈  
<!-- Closes 키워드가 있어야 PR이 머지되었을 때 이슈가 자동으로 닫힙니다. -->
Closes #178 

## 🔍 작업 내용  
- `User`에 `tutorialShown` 필드 추가
- `UserGoalHistoryRepository`에 `existsByUserId` 메서드 추가 
- `OnboardingProgressService` 신규 작성: puppy/이름/목표 이력 기반으로 온보딩 완료 여부를 매 요청마다 계산 (별도 저장 컬럼 없이 파생 계산)
- `TutorialService`/`TutorialController` 신규 작성: `POST /onboarding/tutorial/start`로 튜토리얼 진행 상태 등록 (멱등 처리)
- `GET /auth/me` 응답에 `isPuppyTestCompleted`, `onboardingCompleted`, `tutorialShown` 필드 추가
  - 기존 `isOnboarded` 필드는 구버전 클라이언트 호환을 위해 유지 (값은 `isPuppyTestCompleted`와 동일)
  
## ✅ 체크리스트  
- [x] 기능이 의도대로 정상 동작하는지 확인했습니다.  
- [x] 에러 처리 및 예외 상황을 적절히 검토했습니다.  
- [ ] 관련 문서 및 API 명세를 최신 상태로 유지했습니다.  
- [ ] 배포 관련 설정이나 환경 변수 변경 사항을 반영했습니다.
- [x] 연관된 기능을 맡은 팀원에게 리뷰를 요청하고, 리뷰어로 할당했습니다.

## 💬 Remarks  
<!-- 특이사항, 논의 사항, 배포 관련 안내 등 -->
- 기존 `OnboardingTestService`(강아지 유형 검사)와의 네이밍 혼동을 피하기 위해 신규 클래스는 `Test` 대신 `Progress`로 구분했습니다.

@SeoJin-L-ee 
"온보딩" 용어가 강아지유형검사가 아니라 강아지이름/내이름/목표 3단계 완료 여부를 가리키는 걸로 바뀌었습니다(**피그마 참고**). 
강아지유형검사는 앞으로 "검사(test)"로 따로 구분해서 부를 예정이라, GET /auth/me에서도 isOnboarded 대신 isPuppyTestCompleted를 사용했으니 참고해주세요.
다만 기존 강아지 유형 검사의 엔드포인트 경로(/api/onboarding/test)는 당장은 안 바꾸고, 상황 보면서 프론트랑 협의 후 천천히 바꾸는 걸로 하려고 해요!

@eldeoddt 
GET /auth/me 응답에 필드 추가되었습니다.
- isPuppyTestCompleted: 강아지 유형 검사 완료 여부 (기존 isOnboarded와 같은 값, isOnboarded는 하위호환 위해 유지)
- onboardingCompleted: 강아지이름/내이름/목표설정 3단계 완료 여부
- tutorialShown: 튜토리얼 진행 여부

User 테이블엔 tutorialShown 컬럼(boolean, default는 false)이 추가되었습니다. 참고 부탁드려요!